### PR TITLE
Add `@internal` annotations

### DIFF
--- a/src/Asserts/BaseAssert.php
+++ b/src/Asserts/BaseAssert.php
@@ -11,6 +11,9 @@ use Sinnbeck\DomAssertions\Asserts\Traits\InteractsWithParser;
 use Sinnbeck\DomAssertions\Asserts\Traits\UsesElementAsserts;
 use Sinnbeck\DomAssertions\Support\DomParser;
 
+/**
+ * @internal
+ */
 abstract class BaseAssert
 {
     use UsesElementAsserts;

--- a/src/Asserts/ElementAssert.php
+++ b/src/Asserts/ElementAssert.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Asserts;
 
+/**
+ * @internal
+ */
 class ElementAssert extends BaseAssert
 {
 }

--- a/src/Asserts/FormAssert.php
+++ b/src/Asserts/FormAssert.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Str;
 use Illuminate\Testing\Assert as PHPUnit;
 use PHPUnit\Framework\Assert;
 
+/**
+ * @internal
+ */
 class FormAssert extends BaseAssert
 {
     public function hasAction(string $action): self

--- a/src/Asserts/SelectAssert.php
+++ b/src/Asserts/SelectAssert.php
@@ -6,6 +6,9 @@ namespace Sinnbeck\DomAssertions\Asserts;
 
 use PHPUnit\Framework\Assert;
 
+/**
+ * @internal
+ */
 class SelectAssert extends BaseAssert
 {
     public function containsOption(mixed $attributes): self

--- a/src/Asserts/Traits/CanGatherAttributes.php
+++ b/src/Asserts/Traits/CanGatherAttributes.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Asserts\Traits;
 
+/**
+ * @internal
+ */
 trait CanGatherAttributes
 {
     public function gatherAttributes($type): void

--- a/src/Asserts/Traits/Debugging.php
+++ b/src/Asserts/Traits/Debugging.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Asserts\Traits;
 
+/**
+ * @internal
+ */
 trait Debugging
 {
     public function dump(): self

--- a/src/Asserts/Traits/InteractsWithParser.php
+++ b/src/Asserts/Traits/InteractsWithParser.php
@@ -4,6 +4,9 @@ namespace Sinnbeck\DomAssertions\Asserts\Traits;
 
 use Sinnbeck\DomAssertions\Support\DomParser;
 
+/**
+ * @internal
+ */
 trait InteractsWithParser
 {
     /**

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\ElementAssert;
 use Sinnbeck\DomAssertions\Support\CompareAttributes;
 
+/**
+ * @internal
+ */
 trait UsesElementAsserts
 {
     public function has(string $attribute, mixed $value = null): self

--- a/src/DomAssertionsServiceProvider.php
+++ b/src/DomAssertionsServiceProvider.php
@@ -7,6 +7,9 @@ use Illuminate\Testing\TestResponse;
 use Sinnbeck\DomAssertions\Macros\AssertElementMacro;
 use Sinnbeck\DomAssertions\Macros\AssertFormMacro;
 
+/**
+ * @internal
+ */
 class DomAssertionsServiceProvider extends ServiceProvider
 {
     public function register()

--- a/src/Macros/AssertElementMacro.php
+++ b/src/Macros/AssertElementMacro.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\ElementAssert;
 use Sinnbeck\DomAssertions\Support\DomParser;
 
+/**
+ * @internal
+ */
 class AssertElementMacro
 {
     public function __invoke(): \Closure

--- a/src/Macros/AssertFormMacro.php
+++ b/src/Macros/AssertFormMacro.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\FormAssert;
 use Sinnbeck\DomAssertions\Support\DomParser;
 
+/**
+ * @internal
+ */
 class AssertFormMacro
 {
     public function __invoke(): \Closure

--- a/src/Support/CompareAttributes.php
+++ b/src/Support/CompareAttributes.php
@@ -7,6 +7,9 @@ use Sinnbeck\DomAssertions\Support\Matchers\NoValues;
 use Sinnbeck\DomAssertions\Support\Matchers\Text;
 use Sinnbeck\DomAssertions\Support\Matchers\Values;
 
+/**
+ * @internal
+ */
 class CompareAttributes
 {
     public static function compare($attribute, $value, $actual): bool

--- a/src/Support/DomParser.php
+++ b/src/Support/DomParser.php
@@ -12,6 +12,9 @@ use DOMNodeList;
 use DOMXPath;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
+/**
+ * @internal
+ */
 final class DomParser
 {
     protected DOMElement $root;

--- a/src/Support/HtmlFormatter.php
+++ b/src/Support/HtmlFormatter.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Support;
 
+/**
+ * @internal
+ */
 class HtmlFormatter
 {
     public function format($html)

--- a/src/Support/Matchers/Classes.php
+++ b/src/Support/Matchers/Classes.php
@@ -4,6 +4,9 @@ namespace Sinnbeck\DomAssertions\Support\Matchers;
 
 use Sinnbeck\DomAssertions\Support\Normalize;
 
+/**
+ * @internal
+ */
 class Classes implements Matcher
 {
     public static function compare($expected, $actual): bool

--- a/src/Support/Matchers/NoValues.php
+++ b/src/Support/Matchers/NoValues.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Support\Matchers;
 
+/**
+ * @internal
+ */
 class NoValues implements Matcher
 {
     public static function compare($expected, $actual): bool

--- a/src/Support/Matchers/Text.php
+++ b/src/Support/Matchers/Text.php
@@ -4,6 +4,9 @@ namespace Sinnbeck\DomAssertions\Support\Matchers;
 
 use Sinnbeck\DomAssertions\Support\Normalize;
 
+/**
+ * @internal
+ */
 class Text implements Matcher
 {
     public static function compare($expected, $actual): bool

--- a/src/Support/Matchers/Values.php
+++ b/src/Support/Matchers/Values.php
@@ -2,6 +2,9 @@
 
 namespace Sinnbeck\DomAssertions\Support\Matchers;
 
+/**
+ * @internal
+ */
 class Values implements Matcher
 {
     public static function compare($expected, $actual): bool

--- a/src/Support/Normalize.php
+++ b/src/Support/Normalize.php
@@ -4,6 +4,9 @@ namespace Sinnbeck\DomAssertions\Support;
 
 use Illuminate\Support\Str;
 
+/**
+ * @internal
+ */
 class Normalize
 {
     public static function class(string $class): array


### PR DESCRIPTION
Hey 👋

This PR proposes a tiny, but important change to all classes within the project namespace: [adding `@internal` annotations](https://docs.phpdoc.org/2.9/references/phpdoc/tags/internal.html).

This is important to communicate to the consumers in user-land code as none of the classes are meant to be used directly, but only through the macros which are registered at runtime.

This obviously does not prevent anything, but good IDEs such as PhpStorm tell you that you are not supposed to use the class, like so:

![Example](https://i.gyazo.com/0b75bad4993452dd40a9260fe7c3ecdd.png)