### PR TITLE
Replace Carbon's exception with `BadMethodCallException`

### DIFF
--- a/src/Asserts/BaseAssert.php
+++ b/src/Asserts/BaseAssert.php
@@ -2,7 +2,7 @@
 
 namespace Sinnbeck\DomAssertions\Asserts;
 
-use Carbon\Exceptions\UnknownMethodException;
+use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Sinnbeck\DomAssertions\Asserts\Traits\CanGatherAttributes;
@@ -67,6 +67,6 @@ abstract class BaseAssert
             return $this->doesntContain($elementName, ...$arguments);
         }
 
-        throw new UnknownMethodException($method);
+        throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()', static::class, $method));
     }
 }


### PR DESCRIPTION
Hey 👋

This PR proposes the replacement of Carbon's `UnknownMethodException` with PHP's native `BadMethodCallException` to catch unknown dynamic calls to `BaseAssert` instances.

The reason for this, is that this will most probably confuse users when they encounter this exception as the stack trace is going to contain "Carbon", but direct Carbon usage is nowhere to be found.

With `BadMethodCallException`, there is no confusion possible.