### PR TITLE
Match string within text content

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,10 @@ Livewire::test(UserForm::class)
 | `->isDiv()`                                    | Magic method. Same as `->is('div')`                                                  |
 | `->contains($selector, $attributes, $count)`   | Checks for any children of the current element                                       |
 | `->containsDiv, ['class' => 'foo'], 3)`        | Magic method. Same as `->contains('div', ['class' => 'foo'], 3)`                     |
+| `->containsText($needle, $ignoreCase)`         | Checks if the element's text content contains a specified string                     |
 | `->doesntContain($selector, $attributes)`      | Ensures that there are no matching children                                          |
 | `->doesntContainDiv, ['class' => 'foo'])`      | Magic method. Same as `->doesntContain('div', ['class' => 'foo'])`                   |
+| `->doesntContainText($needle, $ignoreCase)`    | Checks if the element's text content doesn't contain a specified string              |
 | `->find($selector, $callback)`                 | Find a specific child element and get a new AssertElement. Returns the first match.  |
 | `->findDiv(fn (AssertElement $element) => {})` | Magic method. Same as `->find('div', fn (AssertElement $element) => {})`             |
 

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -147,6 +147,42 @@ trait UsesElementAsserts
         return $this;
     }
 
+    public function containsText(string $needle, bool $ignoreCase = false): self
+    {
+        $text = $this->getAttribute('text');
+
+        $assertFunction = $ignoreCase ?
+            'assertStringContainsStringIgnoringCase' :
+            'assertStringContainsString';
+
+        call_user_func(
+            [PHPUnit::class, $assertFunction],
+            $needle,
+            $text,
+            sprintf('Could not find text content "%s" containing %s', $text, $needle)
+        );
+
+        return $this;
+    }
+
+    public function doesntContainText(string $needle, bool $ignoreCase = false): self
+    {
+        $text = $this->getAttribute('text');
+
+        $assertFunction = $ignoreCase ?
+            'assertStringNotContainsStringIgnoringCase' :
+            'assertStringNotContainsString';
+
+        call_user_func(
+            [PHPUnit::class, $assertFunction],
+            $needle,
+            $text,
+            sprintf('Found text content "%s" containing %s', $text, $needle)
+        );
+
+        return $this;
+    }
+
     public function is(string $type): self
     {
         PHPUnit::assertEquals(

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -182,6 +182,27 @@ it('can match text content with duplicate spaces and vertical whitespace', funct
         });
 });
 
+it('can match text content containing a string', function () {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', function (AssertElement $element) {
+            $element->containsText('Bar');
+        });
+});
+
+it('can match text content containing a string ignoring case', function () {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', function (AssertElement $element) {
+            $element->containsText('bar', true);
+        });
+});
+
+it('can match text content not containing a string', function () {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', function (AssertElement $element) {
+            $element->doesntContainText('bar');
+        });
+});
+
 it('can match a class no matter the order', function () {
     $this->get('nesting')
         ->assertElementExists(function (AssertElement $element) {


### PR DESCRIPTION
Currently only exact text content can be tested, like so:

```php
assertElementExists('span.bar', function (AssertElement $element) {
    $element->has('text', 'Foo'); // matches only if text content == 'Foo'
});
```

This PR adds possibility to search within the text content:

```php
assertElementExists('span.bar', function (AssertElement $element) {
    $element->containsText('Foo'); // matches if 'Foo' is within text content, eg. if text content == 'Foo Bar'
});
```