### PR TITLE
Add contains optgroup(s) methods for selects

### DIFF
--- a/src/Asserts/AssertSelect.php
+++ b/src/Asserts/AssertSelect.php
@@ -24,6 +24,22 @@ class AssertSelect extends BaseAssert
         return $this;
     }
 
+    public function containsOptgroup(mixed $attributes): self
+    {
+        $this->contains('optgroup', $attributes);
+
+        return $this;
+    }
+
+    public function containsOptgroups(...$attributes): self
+    {
+        foreach ($attributes as $attribute) {
+            $this->containsOptgroup($attribute);
+        }
+
+        return $this;
+    }
+
     public function hasValue($value): self
     {
         Assert::assertNotNull(

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -207,6 +207,7 @@ it('can parse a select with optgroups', function () {
                     ->containsOptgroups(
                         [
                             'label' => 'Vegetables',
+                            'x-data' => 'none',
                         ],
                         [
                             'label' => 'Minerals',

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -196,6 +196,52 @@ it('can parse a select with options', function () {
         })->assertOk();
 });
 
+it('can parse a select with optgroups', function () {
+    $this->get('form')
+        ->assertFormExists('#form2', function (AssertForm $form) {
+            $form->findSelect('select:nth-of-type(3)', function (AssertSelect $selectAssert) {
+                $selectAssert->has('name', 'things')
+                    ->containsOptgroup([
+                        'label' => 'Animals',
+                    ])
+                    ->containsOptgroups(
+                        [
+                            'label' => 'Vegetables',
+                        ],
+                        [
+                            'label' => 'Minerals',
+                        ]
+                    )
+                    ->containsOptions(
+                        [
+                            'value' => 'dog',
+                            'text' => 'Dog',
+                        ],
+                        [
+                            'value' => 'cat',
+                            'text' => 'Cat',
+                        ],
+                        [
+                            'value' => 'carrot',
+                            'text' => 'Carrot',
+                        ],
+                        [
+                            'value' => 'onion',
+                            'text' => 'Onion',
+                        ],
+                        [
+                            'value' => 'calcium',
+                            'text' => 'Calcium',
+                        ],
+                        [
+                            'value' => 'zinc',
+                            'text' => 'Zinc',
+                        ],
+                    );
+            });
+        })->assertOk();
+});
+
 it('can parse a select with options functional', function () {
     $this->get('form')
         ->assertFormExists('#form2', function (AssertForm $form) {

--- a/tests/views/form.blade.php
+++ b/tests/views/form.blade.php
@@ -37,7 +37,7 @@
                 <option value="dog">Dog</option>
                 <option value="cat">Cat</option>
             </optgroup>
-            <optgroup label="Vegetables">
+            <optgroup label="Vegetables" x-data="none">
                 <option value="carrot">Carrot</option>
                 <option value="onion">Onion</option>
             </optgroup>

--- a/tests/views/form.blade.php
+++ b/tests/views/form.blade.php
@@ -32,6 +32,21 @@
             @endforeach
         </select>
 
+        <select name="things">
+            <optgroup label="Animals">
+                <option value="dog">Dog</option>
+                <option value="cat">Cat</option>
+            </optgroup>
+            <optgroup label="Vegetables">
+                <option value="carrot">Carrot</option>
+                <option value="onion">Onion</option>
+            </optgroup>
+            <optgroup label="Minerals">
+                <option value="calcium">Calcium</option>
+                <option value="zinc">Zinc</option>
+            </optgroup>
+        </select>
+
         <input list="skills" name="skill" value="PHP">
         <datalist id="skills">
             <option value="PHP"></option>


### PR DESCRIPTION
This PR adds extra methods to `AssertSelect` that make it easier to assert optgroups exist and have the correct labels.