### PR TITLE
add assertFormDoesntExist and assertElementDoesntExist macros

### DIFF
--- a/ide-helper.php
+++ b/ide-helper.php
@@ -26,5 +26,11 @@ namespace Illuminate\Testing {
             /** @var \Illuminate\Testing\TestResponse $instance */
             return $instance;
         }
+
+        public function assertFormDoesNotExist($selector = 'form', $method = null, $action = null)
+        {
+            /** @var \Illuminate\Testing\TestResponse $instance */
+            return $instance;
+        }
     }
 }

--- a/ide-helper.php
+++ b/ide-helper.php
@@ -15,6 +15,12 @@ namespace Illuminate\Testing {
             return $instance;
         }
 
+        public function assertElementDoesNotExist($selector, $attributes = [])
+        {
+            /** @var \Illuminate\Testing\TestResponse $instance */
+            return $instance;
+        }
+
         public function assertFormExists($selector = 'form', $callback = null)
         {
             /** @var \Illuminate\Testing\TestResponse $instance */

--- a/ide-helper.php
+++ b/ide-helper.php
@@ -15,7 +15,7 @@ namespace Illuminate\Testing {
             return $instance;
         }
 
-        public function assertElementDoesNotExist($selector, $attributes = [])
+        public function assertElementDoesntExist($selector, $attributes = [])
         {
             /** @var \Illuminate\Testing\TestResponse $instance */
             return $instance;
@@ -27,7 +27,7 @@ namespace Illuminate\Testing {
             return $instance;
         }
 
-        public function assertFormDoesNotExist($selector = 'form', $method = null, $action = null)
+        public function assertFormDoesntExist($selector = 'form', $method = null, $action = null)
         {
             /** @var \Illuminate\Testing\TestResponse $instance */
             return $instance;

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -205,7 +205,7 @@ class TestResponseMacros
                     $sanitizedActionExpected = Str::of($action)->upper()->trim()->finish('/')->start('/')->toString();
                     $sanitizedActionActual = Str::of($parser->getAttributeForRoot('action'))->upper()->trim()->finish('/')->start('/')->toString();
 
-                    $isMatchForAction = $sanitizedActionExpected === $sanitizedActionActual;
+                    $isMatchForAction = CompareAttributes::compare('action', $sanitizedActionExpected, $sanitizedActionActual);
                 }
 
                 if ($action && $method) {

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -6,10 +6,12 @@ namespace Sinnbeck\DomAssertions;
 
 use Closure;
 use DOMException;
+use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Asserts\AssertForm;
+use Sinnbeck\DomAssertions\Support\CompareAttributes;
 use Sinnbeck\DomAssertions\Support\DomParser;
 
 /**
@@ -145,6 +147,74 @@ class TestResponseMacros
 
             if ($callback) {
                 $callback(new AssertForm($this->getContent(), $form));
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertFormDoesNotExist(): Closure
+    {
+        return function ($selector = 'form', $method = null, $action = null): TestResponse {
+            /** @var TestResponse $this */
+            Assert::assertNotEmpty(
+                $this->getContent(),
+                'The view is empty!'
+            );
+
+            try {
+                $parser = DomParser::new($this->getContent());
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            if (!is_string($selector)) {
+                Assert::fail('Invalid selector!');
+            }
+
+            $allForms = $parser->queryAll($selector);
+
+            if (!$method && !$action && $allForms->length > 0) {
+                $failMessage = $selector === 'form'
+                    ? 'A form exists in the response'
+                    : sprintf('Found a matching form for the selector "%s"', $selector);
+                Assert::fail($failMessage);
+            }
+
+            foreach ($allForms as $form) {
+                $parser->setRoot($form);
+
+                $isMatchForMethod = false;
+                if ($method) {
+                    $sanitizedMethodExpected = Str::of($method)->trim()->upper()->toString();
+                    $sanitizedMethodActual = Str::of($parser->getAttributeForRoot('method'))->trim()->upper()->toString();
+
+                    if ($sanitizedMethodExpected === 'POST') {
+                        $isMatchForMethod = CompareAttributes::compare('method', $sanitizedMethodExpected, $sanitizedMethodActual);
+                        $hasHiddenInput = (bool)$parser->query('input[type=hidden][name=_method]');
+                        $isMatchForMethod = $isMatchForMethod && !$hasHiddenInput;
+                    } else {
+                        $isMatchForSpoofMethod = CompareAttributes::compare('method', 'POST', $sanitizedMethodActual);
+                        $isMatchForHiddenInput = (bool)$parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
+                        $isMatchForMethod = $isMatchForSpoofMethod && $isMatchForHiddenInput;
+                    }
+                }
+
+                $isMatchForAction = false;
+                if ($action) {
+                    $sanitizedActionExpected = Str::of($action)->upper()->trim()->finish('/')->start('/')->toString();
+                    $sanitizedActionActual = Str::of($parser->getAttributeForRoot('action'))->upper()->trim()->finish('/')->start('/')->toString();
+
+                    $isMatchForAction = $sanitizedActionExpected === $sanitizedActionActual;
+                }
+
+                if ($action && $method) {
+                    Assert::assertFalse($isMatchForMethod && $isMatchForAction, sprintf('A form exists with method "%s" and action "%s"', $method, $action));
+                } elseif ($action) {
+                    Assert::assertFalse($isMatchForAction, sprintf('A form exists with action "%s"', $action));
+                } else {
+                    Assert::assertFalse($isMatchForMethod, sprintf('A form exists with method "%s"', $method));
+                }
             }
 
             return $this;

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -168,13 +168,13 @@ class TestResponseMacros
                 Assert::fail($exception->getMessage());
             }
 
-            if (!is_string($selector)) {
+            if (! is_string($selector)) {
                 Assert::fail('Invalid selector!');
             }
 
             $allForms = $parser->queryAll($selector);
 
-            if (!$method && !$action && $allForms->length > 0) {
+            if (! $method && ! $action && $allForms->length > 0) {
                 $failMessage = $selector === 'form'
                     ? 'A form exists in the response'
                     : sprintf('Found a matching form for the selector "%s"', $selector);
@@ -191,11 +191,11 @@ class TestResponseMacros
 
                     if ($sanitizedMethodExpected === 'POST') {
                         $isMatchForMethod = CompareAttributes::compare('method', $sanitizedMethodExpected, $sanitizedMethodActual);
-                        $hasHiddenInput = (bool)$parser->query('input[type=hidden][name=_method]');
-                        $isMatchForMethod = $isMatchForMethod && !$hasHiddenInput;
+                        $hasHiddenInput = (bool) $parser->query('input[type=hidden][name=_method]');
+                        $isMatchForMethod = $isMatchForMethod && ! $hasHiddenInput;
                     } else {
                         $isMatchForSpoofMethod = CompareAttributes::compare('method', 'POST', $sanitizedMethodActual);
-                        $isMatchForHiddenInput = (bool)$parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
+                        $isMatchForHiddenInput = (bool) $parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
                         $isMatchForMethod = $isMatchForSpoofMethod && $isMatchForHiddenInput;
                     }
                 }

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -80,6 +80,34 @@ class TestResponseMacros
         };
     }
 
+    public function assertElementDoesNotExist(): Closure
+    {
+        return function ($selector, $attributes = []): TestResponse {
+            /** @var TestResponse $this */
+            Assert::assertNotEmpty(
+                $this->getContent(),
+                'The view is empty!'
+            );
+
+            try {
+                $parser = DomParser::new($this->getContent());
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            if (is_string($selector)) {
+                $element = $parser->query($selector);
+            } else {
+                Assert::fail('Invalid selector!');
+            }
+
+            (new AssertElement($this->getContent(), $element))
+                ->doesntContain($selector, $attributes);
+
+            return $this;
+        };
+    }
+
     public function assertFormExists(): Closure
     {
         return function ($selector = 'form', $callback = null): TestResponse {

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -82,7 +82,7 @@ class TestResponseMacros
         };
     }
 
-    public function assertElementDoesNotExist(): Closure
+    public function assertElementDoesntExist(): Closure
     {
         return function ($selector, $attributes = []): TestResponse {
             /** @var TestResponse $this */
@@ -153,7 +153,7 @@ class TestResponseMacros
         };
     }
 
-    public function assertFormDoesNotExist(): Closure
+    public function assertFormDoesntExist(): Closure
     {
         return function ($selector = 'form', $method = null, $action = null): TestResponse {
             /** @var TestResponse $this */

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -205,7 +205,7 @@ class TestViewMacros
                     $sanitizedActionExpected = Str::of($action)->upper()->trim()->finish('/')->start('/')->toString();
                     $sanitizedActionActual = Str::of($parser->getAttributeForRoot('action'))->upper()->trim()->finish('/')->start('/')->toString();
 
-                    $isMatchForAction = $sanitizedActionExpected === $sanitizedActionActual;
+                    $isMatchForAction = CompareAttributes::compare('action', $sanitizedActionExpected, $sanitizedActionActual);
                 }
 
                 if ($action && $method) {

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -82,7 +82,7 @@ class TestViewMacros
         };
     }
 
-    public function assertElementDoesNotExist(): Closure
+    public function assertElementDoesntExist(): Closure
     {
         return function ($selector, $attributes = []): TestView {
             /** @var TestView $this */
@@ -153,7 +153,7 @@ class TestViewMacros
         };
     }
 
-    public function assertFormDoesNotExist(): Closure
+    public function assertFormDoesntExist(): Closure
     {
         return function ($selector = 'form', $method = null, $action = null): TestView {
             /** @var TestView $this */

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -80,6 +80,34 @@ class TestViewMacros
         };
     }
 
+    public function assertElementDoesNotExist(): Closure
+    {
+        return function ($selector, $attributes = []): TestView {
+            /** @var TestView $this */
+            Assert::assertNotEmpty(
+                (string)$this,
+                'The view is empty!'
+            );
+
+            try {
+                $parser = DomParser::new((string)$this);
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            if (is_string($selector)) {
+                $element = $parser->query($selector);
+            } else {
+                Assert::fail('Invalid selector!');
+            }
+
+            (new AssertElement((string)$this, $element))
+                ->doesntContain($selector, $attributes);
+
+            return $this;
+        };
+    }
+
     public function assertFormExists(): Closure
     {
         return function ($selector = 'form', $callback = null): TestView {

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -6,10 +6,12 @@ namespace Sinnbeck\DomAssertions;
 
 use Closure;
 use DOMException;
+use Illuminate\Support\Str;
 use Illuminate\Testing\TestView;
 use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Asserts\AssertForm;
+use Sinnbeck\DomAssertions\Support\CompareAttributes;
 use Sinnbeck\DomAssertions\Support\DomParser;
 
 /**
@@ -145,6 +147,74 @@ class TestViewMacros
 
             if ($callback) {
                 $callback(new AssertForm((string) $this, $form));
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertFormDoesNotExist(): Closure
+    {
+        return function ($selector = 'form', $method = null, $action = null): TestView {
+            /** @var TestView $this */
+            Assert::assertNotEmpty(
+                (string)$this,
+                'The view is empty!'
+            );
+
+            try {
+                $parser = DomParser::new((string)$this);
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            if (!is_string($selector)) {
+                Assert::fail('Invalid selector!');
+            }
+
+            $allForms = $parser->queryAll($selector);
+
+            if (!$method && !$action && $allForms->length > 0) {
+                $failMessage = $selector === 'form'
+                    ? 'A form exists in the response'
+                    : sprintf('Found a matching form for the selector "%s"', $selector);
+                Assert::fail($failMessage);
+            }
+
+            foreach ($allForms as $form) {
+                $parser->setRoot($form);
+
+                $isMatchForMethod = false;
+                if ($method) {
+                    $sanitizedMethodExpected = Str::of($method)->trim()->upper()->toString();
+                    $sanitizedMethodActual = Str::of($parser->getAttributeForRoot('method'))->trim()->upper()->toString();
+
+                    if ($sanitizedMethodExpected === 'POST') {
+                        $isMatchForMethod = CompareAttributes::compare('method', $sanitizedMethodExpected, $sanitizedMethodActual);
+                        $hasHiddenInput = (bool)$parser->query('input[type=hidden][name=_method]');
+                        $isMatchForMethod = $isMatchForMethod && !$hasHiddenInput;
+                    } else {
+                        $isMatchForSpoofMethod = CompareAttributes::compare('method', 'POST', $sanitizedMethodActual);
+                        $isMatchForHiddenInput = (bool)$parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
+                        $isMatchForMethod = $isMatchForSpoofMethod && $isMatchForHiddenInput;
+                    }
+                }
+
+                $isMatchForAction = false;
+                if ($action) {
+                    $sanitizedActionExpected = Str::of($action)->upper()->trim()->finish('/')->start('/')->toString();
+                    $sanitizedActionActual = Str::of($parser->getAttributeForRoot('action'))->upper()->trim()->finish('/')->start('/')->toString();
+
+                    $isMatchForAction = $sanitizedActionExpected === $sanitizedActionActual;
+                }
+
+                if ($action && $method) {
+                    Assert::assertFalse($isMatchForMethod && $isMatchForAction, sprintf('A form exists with method "%s" and action "%s"', $method, $action));
+                } elseif ($action) {
+                    Assert::assertFalse($isMatchForAction, sprintf('A form exists with action "%s"', $action));
+                } else {
+                    Assert::assertFalse($isMatchForMethod, sprintf('A form exists with method "%s"', $method));
+                }
             }
 
             return $this;

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -87,12 +87,12 @@ class TestViewMacros
         return function ($selector, $attributes = []): TestView {
             /** @var TestView $this */
             Assert::assertNotEmpty(
-                (string)$this,
+                (string) $this,
                 'The view is empty!'
             );
 
             try {
-                $parser = DomParser::new((string)$this);
+                $parser = DomParser::new((string) $this);
             } catch (DOMException $exception) {
                 Assert::fail($exception->getMessage());
             }
@@ -103,7 +103,7 @@ class TestViewMacros
                 Assert::fail('Invalid selector!');
             }
 
-            (new AssertElement((string)$this, $element))
+            (new AssertElement((string) $this, $element))
                 ->doesntContain($selector, $attributes);
 
             return $this;
@@ -158,23 +158,23 @@ class TestViewMacros
         return function ($selector = 'form', $method = null, $action = null): TestView {
             /** @var TestView $this */
             Assert::assertNotEmpty(
-                (string)$this,
+                (string) $this,
                 'The view is empty!'
             );
 
             try {
-                $parser = DomParser::new((string)$this);
+                $parser = DomParser::new((string) $this);
             } catch (DOMException $exception) {
                 Assert::fail($exception->getMessage());
             }
 
-            if (!is_string($selector)) {
+            if (! is_string($selector)) {
                 Assert::fail('Invalid selector!');
             }
 
             $allForms = $parser->queryAll($selector);
 
-            if (!$method && !$action && $allForms->length > 0) {
+            if (! $method && ! $action && $allForms->length > 0) {
                 $failMessage = $selector === 'form'
                     ? 'A form exists in the response'
                     : sprintf('Found a matching form for the selector "%s"', $selector);
@@ -191,11 +191,11 @@ class TestViewMacros
 
                     if ($sanitizedMethodExpected === 'POST') {
                         $isMatchForMethod = CompareAttributes::compare('method', $sanitizedMethodExpected, $sanitizedMethodActual);
-                        $hasHiddenInput = (bool)$parser->query('input[type=hidden][name=_method]');
-                        $isMatchForMethod = $isMatchForMethod && !$hasHiddenInput;
+                        $hasHiddenInput = (bool) $parser->query('input[type=hidden][name=_method]');
+                        $isMatchForMethod = $isMatchForMethod && ! $hasHiddenInput;
                     } else {
                         $isMatchForSpoofMethod = CompareAttributes::compare('method', 'POST', $sanitizedMethodActual);
-                        $isMatchForHiddenInput = (bool)$parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
+                        $isMatchForHiddenInput = (bool) $parser->query("input[type=hidden][name=_method][value={$sanitizedMethodExpected}]");
                         $isMatchForMethod = $isMatchForSpoofMethod && $isMatchForHiddenInput;
                     }
                 }

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -404,32 +404,32 @@ it('can run the example from the readme', function () {
 
 it('can assert an element does not exist', function () {
     $this->get('nesting')
-        ->assertElementDoesNotExist('p', ['class' => 'buzz'])
+        ->assertElementDoesntExist('p', ['class' => 'buzz'])
         ->assertSuccessful();
 });
 
 it('can assert a form element does not exist', function () {
     $this->get('nesting')
-        ->assertFormDoesNotExist();
+        ->assertFormDoesntExist();
 });
 
 it('can assert a form element with a specific spoof method does not exist', function () {
     $this->get('form')
-        ->assertFormDoesNotExist(method: 'DELETE');
+        ->assertFormDoesntExist(method: 'DELETE');
 });
 
 it('accounts for spoof methods when asserting that there is no form with a true POST method', function () {
     $this->get('form') // This view has a spoof PUT form
-    ->assertFormDoesNotExist(method: 'POST');
+        ->assertFormDoesntExist(method: 'POST');
 });
 
 it('can assert a form with a given action does not exist', function () {
     $this->get('form')
-        ->assertFormDoesNotExist(action: '/non-existing-action');
+        ->assertFormDoesntExist(action: '/non-existing-action');
 });
 
 it('can assert a form with a given action and method does not exist', function () {
     $this->get('form')
-        ->assertFormDoesNotExist(method: 'PUT', action: '/non-existing-action')
-        ->assertFormDoesNotExist(method: 'DELETE', action: '/form');
+        ->assertFormDoesntExist(method: 'PUT', action: '/non-existing-action')
+        ->assertFormDoesntExist(method: 'DELETE', action: '/form');
 });

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -401,3 +401,9 @@ it('can run the example from the readme', function () {
             ]);
         });
 });
+
+it('can assert an element does not exist', function () {
+    $this->get('nesting')
+        ->assertElementDoesNotExist('p', ['class' => 'buzz'])
+        ->assertSuccessful();
+});

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -407,3 +407,29 @@ it('can assert an element does not exist', function () {
         ->assertElementDoesNotExist('p', ['class' => 'buzz'])
         ->assertSuccessful();
 });
+
+it('can assert a form element does not exist', function () {
+    $this->get('nesting')
+        ->assertFormDoesNotExist();
+});
+
+it('can assert a form element with a specific spoof method does not exist', function () {
+    $this->get('form')
+        ->assertFormDoesNotExist(method: 'DELETE');
+});
+
+it('accounts for spoof methods when asserting that there is no form with a true POST method', function () {
+    $this->get('form') // This view has a spoof PUT form
+    ->assertFormDoesNotExist(method: 'POST');
+});
+
+it('can assert a form with a given action does not exist', function () {
+    $this->get('form')
+        ->assertFormDoesNotExist(action: '/non-existing-action');
+});
+
+it('can assert a form with a given action and method does not exist', function () {
+    $this->get('form')
+        ->assertFormDoesNotExist(method: 'PUT', action: '/non-existing-action')
+        ->assertFormDoesNotExist(method: 'DELETE', action: '/form');
+});


### PR DESCRIPTION
## Purpose 

Hi there 👋! 

This PR brings in assertions to ensure a given Element does not exist. There is also a dedicated assertion to check that a given form does not exist, in this case, the assertion will take into account spoof methods. 

I'm looking forward to any feedback or suggestions. 

I've been really enjoying using this package, and I think adding these negative assertions will be a great way to improve it even more. 


## Demonstration

<img width="971" alt="image" src="https://github.com/sinnbeck/laravel-dom-assertions/assets/22578748/67177e82-b88f-4345-a274-bd50a6b66605">

## Some concerns 

For the implementation of `assertElementDoesntExist()` f I could leverage the existence of the AssertElement object and just call the doesntContain() method. 

However, for the implementation of `assertFormDoesntExist()`, I couldn't make use of the AssertForm object. 

