### PR TITLE
implement findAll to allow fluent assertions against all elements that match selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ $this->get('/some-route')
         });
     });
 ```
+If you want to make an assertion against all elements that match the selection, you may use 'each'.
+
+```php
+$this->get('/some-route')
+    ->assertElementExists('#overview', function (AssertElement $assert) {
+        $assert->each('li', function (AssertElement $element) {
+            $element->has('class', 'list-item');
+        });
+    });
+```
 
 This means that you can infinitely assert down the dom structure.
 ```php

--- a/README.md
+++ b/README.md
@@ -170,21 +170,21 @@ $this->get('/some-route')
     });
 ```
 
-This means that you can infinitely assert down the dom structure.
+You can also infinitely assert down the dom structure.
 ```php
 $this->get('/some-route')
     ->assertElementExists(function (AssertElement $element) {
         $element->find('div', function (AssertElement $element) {
             $element->is('div');
-            $element->contains('p', function (AssertElement $element) {
+            $element->find('p', function (AssertElement $element) {
                 $element->is('p');
-                $element->contains('#label', function (AssertElement $element) {
+                $element->find('#label', function (AssertElement $element) {
                     $element->is('span');
                 });
             });
-            $element->contains('p:nth-of-type(2)', function (AssertElement $element) {
+            $element->find('p:nth-of-type(2)', function (AssertElement $element) {
                 $element->is('p');
-                $element->contains('.sub-header', function (AssertElement $element) {
+                $element->find('.sub-header', function (AssertElement $element) {
                     $element->is('h4');
                 });
             });

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -73,6 +73,23 @@ trait UsesElementAsserts
         return $this;
     }
 
+    public function findAll(string $selector, $callback): self
+    {
+        $elements = $this->getParser()->queryAll($selector);
+        Assert::assertNotCount(
+            0,
+            $elements,
+            sprintf('Could not find any matching element for selector "%s"', $selector)
+        );
+
+        foreach ($elements as $element) {
+            $elementAssert = new AssertElement($this->getContent(), $element);
+            $callback($elementAssert);
+        }
+
+        return $this;
+    }
+
     public function contains(string $selector, $attributes = null, $count = 0): self
     {
         Assert::assertNotNull(

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -73,7 +73,7 @@ trait UsesElementAsserts
         return $this;
     }
 
-    public function findAll(string $selector, $callback): self
+    public function each(string $selector, $callback): self
     {
         $elements = $this->getParser()->queryAll($selector);
         Assert::assertNotCount(

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -76,8 +76,7 @@ trait UsesElementAsserts
     public function each(string $selector, $callback): self
     {
         $elements = $this->getParser()->queryAll($selector);
-        Assert::assertNotCount(
-            0,
+        Assert::assertNotEmpty(
             $elements,
             sprintf('Could not find any matching element for selector "%s"', $selector)
         );

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -268,6 +268,22 @@ it('can fail finding a nested element with content', function () {
         });
 })->throws(AssertionFailedError::class, 'Could not find a matching "div" with data:');
 
+it('can run assertions against all elements that match the selection', function () {
+    $this->get('form')
+        ->assertOk()
+        ->assertElementExists(fn (AssertElement $view) => $view
+            ->findAll('select', fn (AssertElement $select) => $select->has('name'))
+        );
+});
+
+it('fails when findAll is used but no elements match the selector', function () {
+    $this->get('form')
+        ->assertOk()
+        ->assertElementExists(fn (AssertElement $view) => $view
+            ->findAll('img', fn (AssertElement $image) => $image->has('alt'))
+        );
+})->throws(AssertionFailedError::class);
+
 it('can find a nested element with content functional', function () {
     $this->get('nesting')
         ->assertElementExists(function (AssertElement $element) {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -272,15 +272,15 @@ it('can run assertions against all elements that match the selection', function 
     $this->get('form')
         ->assertOk()
         ->assertElementExists(fn (AssertElement $view) => $view
-            ->findAll('select', fn (AssertElement $select) => $select->has('name'))
+            ->each('select', fn (AssertElement $select) => $select->has('name'))
         );
 });
 
-it('fails when findAll is used but no elements match the selector', function () {
+it('fails when each() is used but no elements match the selector', function () {
     $this->get('form')
         ->assertOk()
         ->assertElementExists(fn (AssertElement $view) => $view
-            ->findAll('img', fn (AssertElement $image) => $image->has('alt'))
+            ->each('img', fn (AssertElement $image) => $image->has('alt'))
         );
 })->throws(AssertionFailedError::class);
 


### PR DESCRIPTION
## Purpose

Hello there 👋,

I believe that, at the moment, the way to make assertions against multiple matches is done through `$assertElement->contains()` and `$assertElement->doesntContain()` methods. 

The limitation of these approaches is that the contains() doesn't allow us to write an assertion that ensures all elements under a given selector respect a specific set of rules. 

For example: 
<b>"Assert all images being rendered have an 'alt' attribute"</b>

```
->assertElementExists(fn(AssertElement $viewRendered) => viewRendered
    ->doesntContain('img', [???]) // Without alt attribute
```

I believe we cannot perform this assertion with the existing resources.  Let me know if I'm mistaken.

My proposed solution is the following:

<img width="864" alt="image" src="https://github.com/sinnbeck/laravel-dom-assertions/assets/22578748/7a03942d-3b3e-4761-8b6a-fe452e8ba075">

------

The reasoning behind this proposal is two-fold:

* It allows us to make sweeping assertions about what must be enforced for all elements in the selection.
* It allows us to continue making fluent assertions over all elements in the selection
<img width="919" alt="image" src="https://github.com/sinnbeck/laravel-dom-assertions/assets/22578748/904b65bd-1de7-4677-bb33-7f0bd3bba349">

* It resembles the `->has->each()` API that exists in the FluentJSON assertion


<img width="986" alt="image" src="https://github.com/sinnbeck/laravel-dom-assertions/assets/22578748/6ca54f97-42e6-437d-a4a0-dcfc4eb0b5cf">

------

I hope this doesn't go against the philosophy of the package.
I'm looking forward to any feedback or suggestions.