### PR TITLE
Laravel 12 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1, 8.0]
-        laravel: ['9.*', '10.*', '11.*']
+        laravel: ['9.*', '10.*', '11.*', '12.*']
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -26,12 +26,18 @@ jobs:
             testbench: 7.*
           - laravel: 11.*
             testbench: ^9.0
+          - laravel: 12.*
+            testbench: ^10.0
         exclude:
           - laravel: 10.*
             php: 8.0
           - laravel: 11.*
             php: 8.1
           - laravel: 11.*
+            php: 8.0
+          - laravel: 12.*
+            php: 8.1
+          - laravel: 12.*
             php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -38,18 +38,18 @@
         "php": "^8.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "illuminate/testing": "^9.0|^10.0|^11.0",
+        "illuminate/testing": "^9.0|^10.0|^11.0|^12.0",
         "symfony/css-selector": "^6.0|^7.0"
     },
     "require-dev": {
         "laravel/pint": "^1.2",
-        "nunomaduro/larastan": "^2.2",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.0|^2.34",
+        "larastan/larastan": "^2.0|^3.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "pestphp/pest": "^1.0|^2.34|^3.7",
         "phpstan/extension-installer": "^1.2",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.1",
-        "vimeo/psalm": "^4.29|^5.22"
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.1|^2.0",
+        "vimeo/psalm": "^4.29|^5.22|^6.6"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Hey! Thanks for the repo, 

I noticed [shift failed updating](https://github.com/sinnbeck/laravel-dom-assertions/pull/24), so this piggy backs and fixes the issue to aid to move to Laravel 12 🚀 

I've hopefully resolved this- main difference being the [larastan repo is now it's own thing](https://packagist.org/packages/nunomaduro/larastan)

[All tests seem to be passing for me](https://github.com/jackbayliss/laravel-dom-assertions/actions/runs/14133330536), but lets see how we get on here.

This would be great to have compatible with Laravel 12  as we use it quite often, and thought I'd give you a hand!

