### PR TITLE
Add assertContainsElement

### DIFF
--- a/ide-helper.php
+++ b/ide-helper.php
@@ -32,6 +32,12 @@ namespace Illuminate\Testing {
             /** @var \Illuminate\Testing\TestResponse $instance */
             return $instance;
         }
+
+        public function assertContainsElement($selector, array $attributes = [])
+        {
+            /** @var \Illuminate\Testing\TestResponse $instance */
+            return $instance;
+        }
     }
 
     class TestView
@@ -65,37 +71,49 @@ namespace Illuminate\Testing {
             /** @var \Illuminate\Testing\TestResponse $instance */
             return $instance;
         }
+
+        public function assertContainsElement($selector, array $attributes = [])
+        {
+            /** @var \Illuminate\Testing\TestResponse $instance */
+            return $instance;
+        }
     }
 
     class TestComponent
     {
         public function assertHtml5()
         {
-            /** @var \Illuminate\Testing\TestResponse $instance */
+            /** @var \Illuminate\Testing\TestComponent $instance */
             return $instance;
         }
 
         public function assertElement($selector = 'body', $callback = null)
         {
-            /** @var \Illuminate\Testing\TestResponse $instance */
+            /** @var \Illuminate\Testing\TestComponent $instance */
             return $instance;
         }
 
         public function assertElementExists($selector = 'body', $callback = null)
         {
-            /** @var \Illuminate\Testing\TestResponse $instance */
+            /** @var \Illuminate\Testing\TestComponent $instance */
             return $instance;
         }
 
         public function assertForm($selector = 'form', $callback = null)
         {
-            /** @var \Illuminate\Testing\TestResponse $instance */
+            /** @var \Illuminate\Testing\TestComponent $instance */
             return $instance;
         }
 
         public function assertFormExists($selector = 'form', $callback = null)
         {
-            /** @var \Illuminate\Testing\TestResponse $instance */
+            /** @var \Illuminate\Testing\TestComponent $instance */
+            return $instance;
+        }
+
+        public function assertContainsElement($selector, array $attributes = [])
+        {
+            /** @var \Illuminate\Testing\TestComponent $instance */
             return $instance;
         }
     }

--- a/src/TestComponentMacros.php
+++ b/src/TestComponentMacros.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sinnbeck\DomAssertions;
 
 use Closure;
+use DOMElement;
 use DOMException;
 use Illuminate\Testing\TestComponent;
 use PHPUnit\Framework\Assert;
@@ -79,6 +80,74 @@ class TestComponentMacros
 
             if ($callback) {
                 $callback(new AssertElement((string) $this, $element));
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertContainsElement(): Closure
+    {
+        return function (string $selector, array $attributes = []): TestComponent {
+            /** @var TestComponent $this */
+            Assert::assertNotEmpty(
+                (string) $this,
+                'The component is empty!'
+            );
+
+            try {
+                $parser = DomParser::new((string) $this);
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            $element = $parser->query($selector);
+
+            Assert::assertNotNull(
+                $element,
+                sprintf('No element found with selector: %s', $selector)
+            );
+
+            if (! $element instanceof DOMElement) {
+                Assert::fail('The element found is not a DOMElement!');
+            }
+
+            foreach ($attributes as $attribute => $expected) {
+                switch ($attribute) {
+                    case 'text':
+                        $actual = trim($element->textContent ?? '');
+                        Assert::assertStringContainsString(
+                            $expected,
+                            $actual,
+                            sprintf(
+                                'Failed asserting that element [%s] text contains "%s". Actual: "%s".',
+                                $selector,
+                                $expected,
+                                $actual
+                            )
+                        );
+                        break;
+
+                    default:
+                        $actual = $element->getAttribute($attribute);
+                        Assert::assertNotFalse(
+                            $actual,
+                            sprintf('Attribute [%s] not found in element [%s].', $attribute, $selector)
+                        );
+
+                        Assert::assertStringContainsString(
+                            $expected,
+                            $actual,
+                            sprintf(
+                                'Failed asserting that attribute [%s] of element [%s] contains "%s". Actual: "%s".',
+                                $attribute,
+                                $selector,
+                                $expected,
+                                $actual
+                            )
+                        );
+                        break;
+                }
             }
 
             return $this;

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sinnbeck\DomAssertions;
 
 use Closure;
+use DOMElement;
 use DOMException;
 use Illuminate\Testing\TestView;
 use PHPUnit\Framework\Assert;
@@ -79,6 +80,75 @@ class TestViewMacros
 
             if ($callback) {
                 $callback(new AssertElement((string) $this, $element));
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertContainsElement(): Closure
+    {
+        return function (string $selector, array $attributes = []): TestView {
+            /** @var TestView $this */
+            Assert::assertNotEmpty(
+                (string) $this,
+                'The view is empty!'
+            );
+
+            try {
+                $parser = DomParser::new((string) $this);
+            } catch (DOMException $exception) {
+                Assert::fail($exception->getMessage());
+            }
+
+            $element = $parser->query($selector);
+
+            Assert::assertNotNull(
+                $element,
+                sprintf('No element found with selector: %s', $selector)
+            );
+
+            if (! $element instanceof DOMElement) {
+                Assert::fail('The element found is not a DOMElement!');
+            }
+
+            foreach ($attributes as $attribute => $expected) {
+                switch ($attribute) {
+                    case 'text':
+                        $actual = trim($element->textContent ?? '');
+                        Assert::assertStringContainsString(
+                            $expected,
+                            $actual,
+                            sprintf(
+                                'Failed asserting that element [%s] text contains "%s". Actual: "%s".',
+                                $selector,
+                                $expected,
+                                $actual
+                            )
+                        );
+                        break;
+
+                    default:
+                        $actual = $element->getAttribute($attribute);
+
+                        Assert::assertNotFalse(
+                            $actual,
+                            sprintf('Attribute [%s] not found in element [%s].', $attribute, $selector)
+                        );
+
+                        Assert::assertStringContainsString(
+                            $expected,
+                            $actual,
+                            sprintf(
+                                'Failed asserting that attribute [%s] of element [%s] contains "%s". Actual: "%s".',
+                                $attribute,
+                                $selector,
+                                $expected,
+                                $actual
+                            )
+                        );
+                        break;
+                }
             }
 
             return $this;

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -23,6 +23,22 @@ it('assertElement alias works for assertElementExists', function () {
         });
 });
 
+it('assertContainsElement works as expects', function () {
+    $this->component(NestedComponent::class)
+        ->assertContainsElement('span.foo', ['text' => 'Foo', 'class' => 'bar foo'])
+        ->assertContainsElement('nav');
+});
+
+it('assertContainsElement throws if selector not found', function () {
+    $this->component(NestedComponent::class)
+        ->assertContainsElement('span.non-existing', ['text' => 'Foo']);
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertContainsElement throws if contains array does not exist', function () {
+    $this->component(NestedComponent::class)
+        ->assertContainsElement('span.foo', ['text' => 'non-existing']);
+})->throws(AssertionFailedError::class, 'Failed asserting that element [span.foo] text contains "non-existing". Actual: "Foo"');
+
 it('can handle an empty component', function () {
     $this->component(EmptyComponent::class)
         ->assertElementExists();

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -10,6 +10,22 @@ it('assertAlias alias works for assertElementExists', function () {
         });
 });
 
+it('assertContainsElement works as expects', function () {
+    $this->get('nesting')
+        ->assertContainsElement('span.foo', ['text' => 'Foo', 'class' => 'bar foo'])
+        ->assertContainsElement('nav');
+});
+
+it('assertContainsElement throws if selector not found', function () {
+    $this->get('nesting')
+        ->assertContainsElement('span.non-existing', ['text' => 'Foo']);
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertContainsElement throws if contains array does not exist', function () {
+    $this->get('nesting')
+        ->assertContainsElement('span.foo', ['text' => 'non-existing']);
+})->throws(AssertionFailedError::class, 'Failed asserting that element [span.foo] text contains "non-existing". Actual: "Foo"');
+
 it('can handle an empty view', function () {
     $this->get('empty')
         ->assertElementExists();

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -3,6 +3,22 @@
 use PHPUnit\Framework\AssertionFailedError;
 use Sinnbeck\DomAssertions\Asserts\AssertElement;
 
+it('assertContainsElement works as expects', function () {
+    $this->view('nesting')
+        ->assertContainsElement('span.foo', ['text' => 'Foo'])
+        ->assertContainsElement('nav');
+});
+
+it('assertContainsElement throws if selector not found', function () {
+    $this->view('nesting')
+        ->assertContainsElement('span.non-existing', ['text' => 'Foo']);
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertContainsElement throws if contains array does not exist', function () {
+    $this->view('nesting')
+        ->assertContainsElement('span.foo', ['text' => 'non-existing']);
+})->throws(AssertionFailedError::class, 'Failed asserting that element [span.foo] text contains "non-existing". Actual: "Foo"');
+
 it('assertElement alias works for assertElementExists', function () {
     $this->view('nesting')
         ->assertElement('body', function (AssertElement $assert) {


### PR DESCRIPTION
This PR introduces a new assertion method: `assertContainsElement`.

It acts as a shorthand for assertElementExists, making it easier to chain assertions directly off a component  keeping it flat and fluent and great for quick, simple checks without sacrificing expressiveness. 

So, all you do is the selector and the attributes. 

```php
$this->view('testing')
    ->assertContainsElement('nav');
    ->assertContainsElement('span.foo', ['text' => 'Foo', 'class' => 'bar foo'])
```

The idea being, for simple assertions such as alert banners etc, we can just do: 

```php
$this->view('testing')
    ->assertContainsElement('div.banner', ['text' => 'Your item was created successfully', 'class' => 'success']);
```

I will probably add an `assertDoesntContainElement` if this gets accepted
