### PR TITLE
Cache parser for assertContainsElement

### DIFF
--- a/src/TestComponentMacros.php
+++ b/src/TestComponentMacros.php
@@ -96,12 +96,14 @@ class TestComponentMacros
             );
 
             try {
-                $parser = DomParser::new((string) $this);
+                if (! isset($this->parser)) {
+                    $this->parser = DomParser::new((string) $this);
+                }
             } catch (DOMException $exception) {
                 Assert::fail($exception->getMessage());
             }
 
-            $element = $parser->query($selector);
+            $element = $this->parser->query($selector);
 
             Assert::assertNotNull(
                 $element,

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -96,12 +96,14 @@ class TestResponseMacros
             );
 
             try {
-                $parser = DomParser::new($this->getContent());
+                if (! isset($this->parser)) {
+                    $this->parser = DomParser::new($this->getContent());
+                }
             } catch (DOMException $exception) {
                 Assert::fail($exception->getMessage());
             }
 
-            $element = $parser->query($selector);
+            $element = $this->parser->query($selector);
 
             Assert::assertNotNull(
                 $element,

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -96,12 +96,14 @@ class TestViewMacros
             );
 
             try {
-                $parser = DomParser::new((string) $this);
+                if (! isset($this->parser)) {
+                    $this->parser = DomParser::new((string) $this);
+                }
             } catch (DOMException $exception) {
                 Assert::fail($exception->getMessage());
             }
 
-            $element = $parser->query($selector);
+            $element = $this->parser->query($selector);
 
             Assert::assertNotNull(
                 $element,


### PR DESCRIPTION
I had a thought, if we constantly chained this method it would be nice to cache the parser to save time!  

