### PR TITLE
Add HTML content assertion methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,34 @@ $this->get('/some-route')
     ->assertDoesntExist('div.not-here');
 ```
 
+### Matching text content
+
+Use `containsText` and `doesntContainText` to assert that the element's text content contains or does not contain a given substring. These methods also support an optional `$ignoreCase` parameter for case-insensitive matching.
+
+```php
+$this->get('/some-route')
+    ->assertElement('h1', function (\Sinnbeck\DomAssertions\Asserts\AssertElement $assert) {
+        $assert->containsText('Page Title');
+    });
+```
+
+- `containsText($needle, $ignoreCase = false)` asserts the element’s text contains a substring.
+- `doesntContainText($needle, $ignoreCase = false)` asserts the element’s text does not contain a substring.
+
+### Matching HTML content
+
+Use `containsHtml` and `doesntContainHtml` to assert that the element's HTML contains or does not contain a given substring. These methods also support an optional `$ignoreCase` parameter for case-insensitive matching.
+
+```php
+$this->get('/some-route')
+    ->assertElement('img', function (\Sinnbeck\DomAssertions\Asserts\AssertElement $assert) {
+        $assert->containsHtml('src="/images/cat.jpg"');
+    });
+```
+
+- `containsHtml($needle, $ignoreCase = false)` asserts the element’s HTML contains a substring.
+- `doesntContainHtml($needle, $ignoreCase = false)` asserts the element’s HTML does not contain a substring.
+
 ### Testing forms
 Testing forms allows using all the dom asserts from above, but has a few special helpers to help test for forms.
 Instead of using `->assertElementExists()` you can use `->assertFormExists()`, or the alias `assertForm()` on the test response.
@@ -384,7 +412,7 @@ Livewire::test(UserForm::class)
 ```
 
 ### Usage with Blade views
-You can also use this package to test blade views. 
+You can also use this package to test blade views.
 ```php
 $this->view('navigation')
     ->assertElementExists('nav > ul', function(AssertElement $ul) {
@@ -418,6 +446,8 @@ $this->component(Navigation::class)
 | `->doesntContain($selector, $attributes)`      | Ensures that there are no matching children                                          |
 | `->doesntContainDiv, ['class' => 'foo'])`      | Magic method. Same as `->doesntContain('div', ['class' => 'foo'])`                   |
 | `->doesntContainText($needle, $ignoreCase)`    | Checks if the element's text content doesn't contain a specified string              |
+| `->containsHtml($needle, $ignoreCase)`         | Checks if the element's HTML contains a specified string                             |
+| `->doesntContainHtml($needle, $ignoreCase)`    | Checks if the element's HTML does not contain a specified string                     |
 | `->find($selector, $callback)`                 | Find a specific child element and get a new AssertElement. Returns the first match.  |
 | `->findDiv(fn (AssertElement $element) => {})` | Magic method. Same as `->find('div', fn (AssertElement $element) => {})`             |
 

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -202,6 +202,44 @@ trait UsesElementAsserts
         return $this;
     }
 
+    public function containsHtml(string $html, bool $ignoreCase = false): self
+    {
+        $content = $this->getContent();
+        if ($ignoreCase) {
+            \PHPUnit\Framework\Assert::assertStringContainsStringIgnoringCase(
+                $html,
+                $content,
+                sprintf('Failed asserting that HTML contains (ignore case): %s', $html)
+            );
+        } else {
+            \PHPUnit\Framework\Assert::assertStringContainsString(
+                $html,
+                $content,
+                sprintf('Failed asserting that HTML contains: %s', $html)
+            );
+        }
+        return $this;
+    }
+
+    public function doesntContainHtml(string $html, bool $ignoreCase = false): self
+    {
+        $content = $this->getContent();
+        if ($ignoreCase) {
+            \PHPUnit\Framework\Assert::assertStringNotContainsStringIgnoringCase(
+                $html,
+                $content,
+                sprintf('Failed asserting that HTML does not contain (ignore case): %s', $html)
+            );
+        } else {
+            \PHPUnit\Framework\Assert::assertStringNotContainsString(
+                $html,
+                $content,
+                sprintf('Failed asserting that HTML does not contain: %s', $html)
+            );
+        }
+        return $this;
+    }
+
     public function is(string $type): self
     {
         PHPUnit::assertEquals(

--- a/tests/HtmlAssertTest.php
+++ b/tests/HtmlAssertTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\AssertionFailedError;
+use Sinnbeck\DomAssertions\Asserts\AssertElement;
+
+it('containsHtml passes when literal HTML is present', function () {
+    $this->view('nesting')
+        ->assertElement('div', function (AssertElement $assert) {
+            $assert->containsHtml('<span></span>');
+        });
+});
+
+it('containsHtml fails when literal HTML is not present', function () {
+    $this->view('nesting')
+        ->assertElement('div', function (AssertElement $assert) {
+            $assert->containsHtml('<strong>nope</strong>');
+        });
+})->throws(AssertionFailedError::class, 'Failed asserting that HTML contains: <strong>nope</strong>');
+
+it('doesntContainHtml passes when literal HTML is not present', function () {
+    $this->view('nesting')
+        ->assertElement('div', function (AssertElement $assert) {
+            $assert->doesntContainHtml('<strong>nope</strong>');
+        });
+});
+
+it('doesntContainHtml fails when literal HTML is present', function () {
+    $this->view('nesting')
+        ->assertElement('div', function (AssertElement $assert) {
+            $assert->doesntContainHtml('<span></span>');
+        });
+})->throws(AssertionFailedError::class, 'Failed asserting that HTML does not contain: <span></span>');
+
+it('containsHtml works for various attributes and tags', function () {
+    $this->view('media')
+        ->assertElement('#gallery', function (AssertElement $assert) {
+            $assert->containsHtml('src="/images/cat.jpg"');
+            $assert->containsHtml('alt="A cat"');
+            $assert->containsHtml('data-id="123"');
+            $assert->containsHtml('type="image/webp"');
+            $assert->containsHtml('id="gallery"');
+            $assert->containsHtml('data-testid="gallery-1"');
+            $assert->containsHtml('aria-hidden="false"');
+            $assert->containsHtml('<picture>');
+        });
+});
+
+it('doesntContainHtml works for absent or wrong attributes and tags', function () {
+    $this->view('media')
+        ->assertElement('#gallery', function (AssertElement $assert) {
+            $assert->doesntContainHtml('src="/images/hamster.jpg"');
+            $assert->doesntContainHtml('data-id="000"');
+            $assert->doesntContainHtml('alt="A hamster"');
+            $assert->doesntContainHtml('type="image/png"');
+            $assert->doesntContainHtml('charset="UTF-16"');
+            $assert->doesntContainHtml('<svg');
+        });
+    $this->view('media')
+        ->assertElement('body', function (AssertElement $assert) {
+            $assert->doesntContainHtml('<iframe');
+        });
+});
+
+it('containsHtml respects partial matches and whitespace', function () {
+    $this->view('nesting')
+        ->assertElement('p.foo.bar', function (AssertElement $assert) {
+            $assert->containsHtml('<span>Bar</span>');
+        });
+});
+
+it('containsHtml can match script tag content', function () {
+    $this->view('media')
+        ->assertElement('script#config', function (AssertElement $assert) {
+            $assert->containsHtml('"feature": "media"');
+            $assert->containsHtml('"enabled": true');
+        });
+});
+
+it('containsHtml supports boolean-like attributes present', function () {
+    $this->view('nesting')
+        ->assertElement('meta[charset]', function (AssertElement $assert) {
+            $assert->containsHtml('charset="UTF-8"');
+        });
+});
+
+it('containsHtml can match attribute without quotes if normalized', function () {
+    $this->view('nesting')
+        ->assertElement('meta[name="viewport"]', function (AssertElement $assert) {
+            $assert->containsHtml('name="viewport"');
+            $assert->containsHtml('content="width=device-width');
+        });
+});
+
+it('containsHtml can find stylesheet link href', function () {
+    $this->view('media')
+        ->assertElement('head', function (AssertElement $assert) {
+            $assert->containsHtml('<link href="/css/app.css" rel="stylesheet">');
+        });
+});
+
+it('doesntContainHtml can fail on hidden substring', function () {
+    $this->view('media')
+        ->assertElement('#gallery', function (AssertElement $assert) {
+            $assert->doesntContainHtml('hidden');
+        });
+})->throws(AssertionFailedError::class, 'Failed asserting that HTML does not contain: hidden');

--- a/tests/views/media.blade.php
+++ b/tests/views/media.blade.php
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Media</title>
+        <link rel="stylesheet" href="/css/app.css">
+        <style>
+            .hidden { display: none; }
+        </style>
+    </head>
+    <body>
+        <div id="gallery" data-testid="gallery-1" aria-hidden="false">
+            <img src="/images/cat.jpg" alt="A cat" class="photo hidden" data-id="123" />
+            <img src="/images/dog.jpg" alt="A dog" class="photo" data-id="456" />
+            <picture>
+                <source srcset="/images/bird.webp" type="image/webp">
+                <img src="/images/bird.jpg" alt="A bird" class="photo" data-id="789" />
+            </picture>
+        </div>
+        <script type="application/json" id="config">
+            {"feature": "media", "enabled": true}
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
# HTML Content Assertions for DOM Elements

## Overview

This PR introduces a cleaner way to test HTML content in DOM elements. New assertion methods let you verify whether specific HTML snippets exist within an element, complete with optional case-insensitive matching for flexibility.

### New Assertion Methods

Two companion methods have been added to the `AssertElement` class that make HTML content testing straightforward:

- **`containsHtml($needle, $ignoreCase = false)`** Assert that an element contains a specific HTML substring
- **`doesntContainHtml($needle, $ignoreCase = false)`** Assert that an element doesn't contain a specific HTML substring

The optional `$ignoreCase` parameter gives control over whether the matching should be case-sensitive or not, making tests more adaptable to real-world scenarios.

### Documentation

The `README.md` has been updated with:

- Clear explanations of how to use both new methods, with practical examples
- A reference table entry for quick lookup of the assertion methods

### Test Coverage

To ensure these methods work reliably:

- A new test suite (`tests/HtmlAssertTest.php`) covers positive cases, negative cases, attribute matching, tag matching, partial matches, and error handling
- Added `tests/views/media.blade.php` with realistic HTML markup that the tests exercise