### PR TITLE
Update phpstan-baseline.neon

### DIFF
--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
     level: 5
     paths:
-        - src
+        - %rootDir%/../../../src
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true


### PR DESCRIPTION
Was having a few issues on Windows when running  `vendor/bin/phpstan analyse --ansi --memory-limit=1g` 

This ensures it always goes to the right src folder