### PR TITLE
normalize text in assertContainsElement

### DIFF
--- a/src/TestComponentMacros.php
+++ b/src/TestComponentMacros.php
@@ -13,6 +13,7 @@ use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Asserts\AssertForm;
 use Sinnbeck\DomAssertions\Asserts\AssertSelect;
 use Sinnbeck\DomAssertions\Support\DomParser;
+use Sinnbeck\DomAssertions\Support\Normalize;
 
 /**
  * @internal
@@ -129,7 +130,7 @@ class TestComponentMacros
             foreach ($attributes as $attribute => $expected) {
                 switch ($attribute) {
                     case 'text':
-                        $actual = trim($element->textContent);
+                        $actual = Normalize::text($element->textContent);
                         Assert::assertStringContainsString(
                             $expected,
                             $actual,

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -13,6 +13,7 @@ use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Asserts\AssertForm;
 use Sinnbeck\DomAssertions\Asserts\AssertSelect;
 use Sinnbeck\DomAssertions\Support\DomParser;
+use Sinnbeck\DomAssertions\Support\Normalize;
 
 /**
  * @internal
@@ -138,7 +139,7 @@ class TestResponseMacros
             foreach ($attributes as $attribute => $expected) {
                 switch ($attribute) {
                     case 'text':
-                        $actual = trim($element->textContent);
+                        $actual = Normalize::text($element->textContent);
                         Assert::assertStringContainsString(
                             $expected,
                             $actual,

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -13,6 +13,7 @@ use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Asserts\AssertForm;
 use Sinnbeck\DomAssertions\Asserts\AssertSelect;
 use Sinnbeck\DomAssertions\Support\DomParser;
+use Sinnbeck\DomAssertions\Support\Normalize;
 
 /**
  * @internal
@@ -129,7 +130,7 @@ class TestViewMacros
             foreach ($attributes as $attribute => $expected) {
                 switch ($attribute) {
                     case 'text':
-                        $actual = trim($element->textContent);
+                        $actual = Normalize::text($element->textContent);
                         Assert::assertStringContainsString(
                             $expected,
                             $actual,

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -53,6 +53,16 @@ it('assertContainsElement throws if contains attribute does not exist', function
         ->assertContainsElement('span.foo', ['non-existing-attribute' => 'non-existing']);
 })->throws(AssertionFailedError::class, 'Attribute [non-existing-attribute] not found in element [span.foo]');
 
+it('assertContainsElement matches text across child elements', function (): void {
+    $this->get('nesting')
+        ->assertContainsElement('p.foo', ['text' => 'Foo Bar']);
+});
+
+it('assertContainsElement matches text separated by a br tag', function (): void {
+    $this->get('nesting')
+        ->assertContainsElement('small.multi-line', ['text' => 'Foo Bar']);
+});
+
 it('assertFormExists works as expects', function (): void {
     $this->component(FormComponent::class)
         ->assertFormExists('#form1', static function (AssertForm $form): void {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -38,6 +38,16 @@ it('assertContainsElement throws if contains attribute does not exist', function
         ->assertContainsElement('span.foo', ['non-existing-attribute' => 'non-existing']);
 })->throws(AssertionFailedError::class, 'Attribute [non-existing-attribute] not found in element [span.foo]');
 
+it('assertContainsElement matches text across child elements', function (): void {
+    $this->get('nesting')
+        ->assertContainsElement('p.foo', ['text' => 'Foo Bar']);
+});
+
+it('assertContainsElement matches text separated by a br tag', function (): void {
+    $this->get('nesting')
+        ->assertContainsElement('small.multi-line', ['text' => 'Foo Bar']);
+});
+
 it('can handle an empty view', function (): void {
     $this->get('empty')
         ->assertElementExists();

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -30,6 +30,16 @@ it('assertContainsElement throws if contains attribute does not exist', function
         ->assertContainsElement('span.foo', ['non-existing-attribute' => 'non-existing']);
 })->throws(AssertionFailedError::class, 'Attribute [non-existing-attribute] not found in element [span.foo]');
 
+it('assertContainsElement matches text across child elements', function (): void {
+    $this->view('nesting')
+        ->assertContainsElement('p.foo', ['text' => 'Foo Bar']);
+});
+
+it('assertContainsElement matches text separated by a br tag', function (): void {
+    $this->view('nesting')
+        ->assertContainsElement('small.multi-line', ['text' => 'Foo Bar']);
+});
+
 it('assertElement alias works for assertElementExists', function (): void {
     $this->view('nesting')
         ->assertElement('body', static function (AssertElement $assert): void {

--- a/tests/views/nesting.blade.php
+++ b/tests/views/nesting.blade.php
@@ -26,6 +26,10 @@
                 Foo
                 <span>Bar</span>
             </p>
+            <small class="multi-line">
+                Foo<br>
+                Bar
+            </small>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Normal assertions normalize the text, however assertContainsElement does not.