### PR TITLE
Allow `contains('selector', 'text value')` shorthand

### DIFF
--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -104,6 +104,10 @@ trait UsesElementAsserts
             $attributes = null;
         }
 
+        if (is_string($attributes)) {
+            $attributes = ['text' => $attributes];
+        }
+
         if (! $attributes && ! $count) {
             return $this;
         }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -482,4 +482,11 @@ it('multiple views can be tested in the same test', function (): void {
 
     expect(fn () => $this->component(LivewireAttributeComponent::class)->assertContainsElement('span.foo', ['text' => 'Foo']))
         ->toThrow(AssertionFailedError::class, 'No element found with selector: span.foo');
+
+    it('can find text simplified', function (): void {
+        $this->component(NestedComponent::class)
+            ->assertElementExists(static function (AssertElement $element): void {
+                $element->contains('span', 'Foo');
+            });
+    });
 });

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -482,11 +482,11 @@ it('multiple views can be tested in the same test', function (): void {
 
     expect(fn () => $this->component(LivewireAttributeComponent::class)->assertContainsElement('span.foo', ['text' => 'Foo']))
         ->toThrow(AssertionFailedError::class, 'No element found with selector: span.foo');
+});
 
-    it('can find text simplified', function (): void {
-        $this->component(NestedComponent::class)
-            ->assertElementExists(static function (AssertElement $element): void {
-                $element->contains('span', 'Foo');
-            });
-    });
+it('can find text simplified', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementExists(static function (AssertElement $element): void {
+            $element->contains('span', 'Foo');
+        });
 });

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -546,3 +546,11 @@ it('multiple views can be tested in the same test', function (): void {
         ->toThrow(AssertionFailedError::class, 'No element found with selector: span.foo');
 
 });
+
+
+it('can find text simplified', function (): void {
+    $this->get('nesting')
+        ->assertElementExists(static function (AssertElement $element): void {
+            $element->contains('span', 'Foo');
+        });
+});

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -547,7 +547,6 @@ it('multiple views can be tested in the same test', function (): void {
 
 });
 
-
 it('can find text simplified', function (): void {
     $this->get('nesting')
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use Sinnbeck\DomAssertions\Asserts\AssertElement;
 
 it('assertDoesntExist works as expected', function (): void {
-    $this->get('nesting')
+    $this->view('nesting')
         ->assertDoesntExist('span.fake')
         ->assertDoesntExist('nav.fake');
 });
@@ -444,22 +444,29 @@ it('can match on livewire contains as attribute', function (): void {
 });
 
 it('multiple views can be tested in the same test', function (): void {
-    $this->get('nesting')
+    $this->view('nesting')
         ->assertDoesntExist('span.fake')
         ->assertDoesntExist('nav.fake')
         ->assertElementExists(static function (AssertElement $element): void {
             $element->contains('nav');
         });
 
-    $this->get('livewire')
+    $this->view('livewire')
         ->assertElementExists('input')
         ->assertElementExists(static function (AssertElement $element): void {
             $element->contains('input[wire\:model="foo"]');
         });
 
-    $this->get('nesting')
+    $this->view('nesting')
         ->assertContainsElement('span.foo', ['text' => 'Foo']);
 
-    expect(fn () => $this->get('livewire')->assertContainsElement('span.foo', ['text' => 'Foo']))
+    expect(fn () => $this->view('livewire')->assertContainsElement('span.foo', ['text' => 'Foo']))
         ->toThrow(AssertionFailedError::class, 'No element found with selector: span.foo');
+
+    it('can find text simplified', function (): void {
+        $this->view('nesting')
+            ->assertElementExists(static function (AssertElement $element): void {
+                $element->contains('span', 'Foo');
+            });
+    });
 });

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -462,11 +462,11 @@ it('multiple views can be tested in the same test', function (): void {
 
     expect(fn () => $this->view('livewire')->assertContainsElement('span.foo', ['text' => 'Foo']))
         ->toThrow(AssertionFailedError::class, 'No element found with selector: span.foo');
+});
 
-    it('can find text simplified', function (): void {
-        $this->view('nesting')
-            ->assertElementExists(static function (AssertElement $element): void {
-                $element->contains('span', 'Foo');
-            });
-    });
+it('can find text simplified', function (): void {
+    $this->view('nesting')
+        ->assertElementExists(static function (AssertElement $element): void {
+            $element->contains('span', 'Foo');
+        });
 });


### PR DESCRIPTION
## Before

Either, we use `containsText()` to benefit from grouping and no need to do the `['text' => ...]` wrapping:

```php
->assertElement('#content', static function (AssertElement $element) {
    $element->find('h1', static function (AssertElement $element) {
        $element->containsText('Foo bar');
    });
    $element->find('h2', static function (AssertElement $element) {
        $element->containsText('Bar foo');
    });
})
```

Or, we have fewer lines, but repeat selectors, with the longer method:

```php
->assertContainsElement('#content h1', ['text' => 'Foo bar'])
->assertContainsElement('#content h2', ['text' => 'Bar foo'])
```

Or, we keep the group and use the short `contains()` but need to pass array:

```php
->assertElement('#content', static function (AssertElement $element) {
    $element->contains('h1', ['text' => 'Foo bar']);
    $element->contains('h2', ['text' => 'Bar foo']);
})
```

## After:

With this change, we be smarter about the `$attributes` parameter:

```php
->assertElement('#content', static function (AssertElement $element) {
    $element->contains('h1', 'Foo bar');
    $element->contains('h2', 'Bar foo');
})
```