### PR TITLE
containsText normalisation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,47 @@ composer require sinnbeck/laravel-dom-assertions --dev
  composer require sinnbeck/laravel-dom-assertions:^2.0 --dev
  ```
 
+
+### Whitespace normalisation
+
+By default `containsText()` / `doesntContainText()` compare text exactly as it appears in the DOM. If your templates produce a lot of incidental whitespace (indented Blade, multi-line content, `\r\n` line endings) you have a few options.
+
+**Per call:**
+
+```php
+$element->containsText('Hello World', ignoreCase: false, normalizeWhitespace: true);
+```
+
+**Globally, this can be done via `TestCase::setUp()` or `AppServiceProvider::boot()`:
+
+```php
+config()->set('dom-assertions.normalize_whitespace', true);
+```
+
+**or via a published config file** if you prefer files:
+
+```bash
+php artisan vendor:publish --tag=dom-assertions-config
+```
+
+This will create `config/dom-assertions.php`:
+
+```php
+return [
+    /*
+    | When enabled, text comparisons performed by `containsText` and
+    | `doesntContainText` will collapse consecutive whitespace and trim
+    | vertical whitespace from both the needle and haystack by default.
+    |
+    | This can still be overridden per-call by passing an explicit boolean
+    | as the third argument to those assertions.
+    */
+    'normalize_whitespace' => true,
+];
+```
+
+With the global default enabled, you can still force the original strict behaviour for a single assertion by passing `normalizeWhitespace: false`.
+
 ## Example
 
 Imagine we have a view with this html
@@ -434,10 +475,10 @@ $this->component(Navigation::class)
 | `->isDiv()`                                    | Magic method. Same as `->is('div')`                                                  |
 | `->contains($selector, $attributes, $count)`   | Checks for any children of the current element                                       |
 | `->containsDiv, ['class' => 'foo'], 3)`        | Magic method. Same as `->contains('div', ['class' => 'foo'], 3)`                     |
-| `->containsText($needle, $ignoreCase)`         | Checks if the element's text content contains a specified string                     |
+| `->containsText($needle, $ignoreCase, $normalizeWhitespace)` | Checks if the element's text content contains a specified string. `$normalizeWhitespace` defaults to the `dom-assertions.normalize_whitespace` config value when null |
 | `->doesntContain($selector, $attributes)`      | Ensures that there are no matching children                                          |
 | `->doesntContainDiv, ['class' => 'foo'])`      | Magic method. Same as `->doesntContain('div', ['class' => 'foo'])`                   |
-| `->doesntContainText($needle, $ignoreCase)`    | Checks if the element's text content doesn't contain a specified string              |
+| `->doesntContainText($needle, $ignoreCase, $normalizeWhitespace)` | Checks if the element's text content doesn't contain a specified string. `$normalizeWhitespace` defaults to the `dom-assertions.normalize_whitespace` config value when null |
 | `->find($selector, $callback)`                 | Find a specific child element and get a new AssertElement. Returns the first match.  |
 | `->findDiv(fn (AssertElement $element) => {})` | Magic method. Same as `->find('div', fn (AssertElement $element) => {})`             |
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By default `containsText()` / `doesntContainText()` compare text exactly as it a
 $element->containsText('Hello World', ignoreCase: false, normalizeWhitespace: true);
 ```
 
-**Globally, this can be done via `TestCase::setUp()` or `AppServiceProvider::boot()`:
+**Globally, this can be done in your `TestCase::setUp()` or `AppServiceProvider::boot()`:
 
 ```php
 config()->set('dom-assertions.normalize_whitespace', true);
@@ -48,7 +48,7 @@ config()->set('dom-assertions.normalize_whitespace', true);
 php artisan vendor:publish --tag=dom-assertions-config
 ```
 
-This will create `config/dom-assertions.php`:
+This will create a file at `config/dom-assertions.php`:
 
 ```php
 return [

--- a/config/dom-assertions.php
+++ b/config/dom-assertions.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Normalize Whitespace
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, text comparisons performed by `containsText` and
+    | `doesntContainText` will collapse consecutive whitespace and trim
+    | vertical whitespace from both the needle and haystack by default.
+    |
+    | This can still be overridden per-call by passing an explicit boolean
+    | as the third argument to those assertions.
+    |
+    */
+    'normalize_whitespace' => false,
+];

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -171,35 +171,47 @@ trait UsesElementAsserts
         return $this;
     }
 
-    public function containsText(string $needle, bool $ignoreCase = false): self
+    public function containsText(string $needle, bool $ignoreCase = false, bool $normalizeWhitespace = false): self
     {
-        $rawText = $this->getAttribute('text');
-        $normalizedText = Normalize::text($rawText);
+        $text = $this->getAttribute('text');
 
-        $compare = $ignoreCase
-            ? static fn (string $haystack, string $needle): bool => stripos($haystack, $needle) !== false
-            : static fn (string $haystack, string $needle): bool => str_contains($haystack, $needle);
+        if ($normalizeWhitespace) {
+            $needle = Normalize::text($needle);
+            $text = Normalize::text($text);
+        }
 
-        PHPUnit::assertTrue(
-            $compare($normalizedText, $needle) || $compare($rawText, $needle),
-            sprintf('Could not find text content "%s" containing %s within: %s', $rawText, $needle, $this->getSelectors())
+        $assertFunction = $ignoreCase ?
+            'assertStringContainsStringIgnoringCase' :
+            'assertStringContainsString';
+
+        call_user_func(
+            [PHPUnit::class, $assertFunction],
+            $needle,
+            $text,
+            sprintf('Could not find text content "%s" containing %s within: %s', $text, $needle, $this->getSelectors())
         );
 
         return $this;
     }
 
-    public function doesntContainText(string $needle, bool $ignoreCase = false): self
+    public function doesntContainText(string $needle, bool $ignoreCase = false, bool $normalizeWhitespace = false): self
     {
-        $rawText = $this->getAttribute('text');
-        $normalizedText = Normalize::text($rawText);
+        $text = $this->getAttribute('text');
 
-        $compare = $ignoreCase
-            ? static fn (string $haystack, string $needle): bool => stripos($haystack, $needle) !== false
-            : static fn (string $haystack, string $needle): bool => str_contains($haystack, $needle);
+        if ($normalizeWhitespace) {
+            $needle = Normalize::text($needle);
+            $text = Normalize::text($text);
+        }
 
-        PHPUnit::assertFalse(
-            $compare($normalizedText, $needle) || $compare($rawText, $needle),
-            sprintf('Found text content "%s" containing %s within: %s', $rawText, $needle, $this->getSelectors())
+        $assertFunction = $ignoreCase ?
+            'assertStringNotContainsStringIgnoringCase' :
+            'assertStringNotContainsString';
+
+        call_user_func(
+            [PHPUnit::class, $assertFunction],
+            $needle,
+            $text,
+            sprintf('Found text content "%s" containing %s within: %s', $text, $needle, $this->getSelectors())
         );
 
         return $this;

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -171,11 +171,11 @@ trait UsesElementAsserts
         return $this;
     }
 
-    public function containsText(string $needle, bool $ignoreCase = false, bool $normalizeWhitespace = false): self
+    public function containsText(string $needle, bool $ignoreCase = false, ?bool $normalizeWhitespace = null): self
     {
         $text = $this->getAttribute('text');
 
-        if ($normalizeWhitespace) {
+        if ($normalizeWhitespace ?? (bool) config('dom-assertions.normalize_whitespace', false)) {
             $needle = Normalize::text($needle);
             $text = Normalize::text($text);
         }
@@ -194,11 +194,11 @@ trait UsesElementAsserts
         return $this;
     }
 
-    public function doesntContainText(string $needle, bool $ignoreCase = false, bool $normalizeWhitespace = false): self
+    public function doesntContainText(string $needle, bool $ignoreCase = false, ?bool $normalizeWhitespace = null): self
     {
         $text = $this->getAttribute('text');
 
-        if ($normalizeWhitespace) {
+        if ($normalizeWhitespace ?? (bool) config('dom-assertions.normalize_whitespace', false)) {
             $needle = Normalize::text($needle);
             $text = Normalize::text($text);
         }

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -6,6 +6,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 use PHPUnit\Framework\Assert;
 use Sinnbeck\DomAssertions\Asserts\AssertElement;
 use Sinnbeck\DomAssertions\Support\CompareAttributes;
+use Sinnbeck\DomAssertions\Support\Normalize;
 
 /**
  * @internal
@@ -172,17 +173,16 @@ trait UsesElementAsserts
 
     public function containsText(string $needle, bool $ignoreCase = false): self
     {
-        $text = $this->getAttribute('text');
+        $rawText = $this->getAttribute('text');
+        $normalizedText = Normalize::text($rawText);
 
-        $assertFunction = $ignoreCase ?
-            'assertStringContainsStringIgnoringCase' :
-            'assertStringContainsString';
+        $compare = $ignoreCase
+            ? static fn (string $haystack, string $needle): bool => stripos($haystack, $needle) !== false
+            : static fn (string $haystack, string $needle): bool => str_contains($haystack, $needle);
 
-        call_user_func(
-            [PHPUnit::class, $assertFunction],
-            $needle,
-            $text,
-            sprintf('Could not find text content "%s" containing %s within: %s', $text, $needle, $this->getSelectors())
+        PHPUnit::assertTrue(
+            $compare($normalizedText, $needle) || $compare($rawText, $needle),
+            sprintf('Could not find text content "%s" containing %s within: %s', $rawText, $needle, $this->getSelectors())
         );
 
         return $this;
@@ -190,17 +190,16 @@ trait UsesElementAsserts
 
     public function doesntContainText(string $needle, bool $ignoreCase = false): self
     {
-        $text = $this->getAttribute('text');
+        $rawText = $this->getAttribute('text');
+        $normalizedText = Normalize::text($rawText);
 
-        $assertFunction = $ignoreCase ?
-            'assertStringNotContainsStringIgnoringCase' :
-            'assertStringNotContainsString';
+        $compare = $ignoreCase
+            ? static fn (string $haystack, string $needle): bool => stripos($haystack, $needle) !== false
+            : static fn (string $haystack, string $needle): bool => str_contains($haystack, $needle);
 
-        call_user_func(
-            [PHPUnit::class, $assertFunction],
-            $needle,
-            $text,
-            sprintf('Found text content "%s" containing %s within: %s', $text, $needle, $this->getSelectors())
+        PHPUnit::assertFalse(
+            $compare($normalizedText, $needle) || $compare($rawText, $needle),
+            sprintf('Found text content "%s" containing %s within: %s', $rawText, $needle, $this->getSelectors())
         );
 
         return $this;

--- a/src/DomAssertionsServiceProvider.php
+++ b/src/DomAssertionsServiceProvider.php
@@ -9,8 +9,17 @@ use Illuminate\Testing\TestView;
 
 class DomAssertionsServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/dom-assertions.php', 'dom-assertions');
+    }
+
     public function boot(): void
     {
+        $this->publishes([
+            __DIR__.'/../config/dom-assertions.php' => $this->app->configPath('dom-assertions.php'),
+        ], 'dom-assertions-config');
+
         if ($this->app->runningUnitTests()) {
             TestResponse::mixin(new TestResponseMacros);
             TestView::mixin(new TestViewMacros);

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -280,17 +280,17 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
-it('matches containsText across collapsed whitespace', function (): void {
+it('matches containsText across collapsed whitespace when normalizing', function (): void {
     $this->component(Html5Component::class)
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->containsText('Foo Bar');
+            $element->containsText('Foo Bar', normalizeWhitespace: true);
         });
 });
 
-it('matches doesntContainText against collapsed whitespace', function (): void {
+it('matches doesntContainText across collapsed whitespace when normalizing', function (): void {
     $this->component(Html5Component::class)
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->doesntContainText('Bar Foo');
+            $element->doesntContainText('Bar Foo', normalizeWhitespace: true);
         });
 });
 

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -280,6 +280,20 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
+it('matches containsText across collapsed whitespace', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsText('Foo Bar');
+        });
+});
+
+it('matches doesntContainText against collapsed whitespace', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainText('Bar Foo');
+        });
+});
+
 it('can match a class no matter the order', function (): void {
     $this->component(Html5Component::class)
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -264,24 +264,17 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
-it('matches containsText across collapsed whitespace', function (): void {
+it('matches containsText across collapsed whitespace when normalizing', function (): void {
     $this->get('nesting')
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->containsText('Foo Bar');
+            $element->containsText('Foo Bar', normalizeWhitespace: true);
         });
 });
 
-it('matches containsText against raw multiline text as a fallback', function (): void {
-    $this->get('nesting')
-        ->assertElementExists('pre.code', static function (AssertElement $element): void {
-            $element->containsText("line one\nline two");
-        });
-});
-
-it('matches doesntContainText against collapsed whitespace', function (): void {
+it('matches doesntContainText across collapsed whitespace when normalizing', function (): void {
     $this->get('nesting')
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->doesntContainText('Bar Foo');
+            $element->doesntContainText('Bar Foo', normalizeWhitespace: true);
         });
 });
 

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -264,6 +264,27 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
+it('matches containsText across collapsed whitespace', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsText('Foo Bar');
+        });
+});
+
+it('matches containsText against raw multiline text as a fallback', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('pre.code', static function (AssertElement $element): void {
+            $element->containsText("line one\nline two");
+        });
+});
+
+it('matches doesntContainText against collapsed whitespace', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainText('Bar Foo');
+        });
+});
+
 it('can match a class no matter the order', function (): void {
     $this->get('nesting')
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -263,6 +263,27 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
+it('matches containsText across collapsed whitespace', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsText('Foo Bar');
+        });
+});
+
+it('matches containsText against raw multiline text as a fallback', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('pre.code', static function (AssertElement $element): void {
+            $element->containsText("line one\nline two");
+        });
+});
+
+it('matches doesntContainText against collapsed whitespace', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainText('Bar Foo');
+        });
+});
+
 it('can match a class no matter the order', function (): void {
     $this->view('nesting')
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -263,24 +263,17 @@ it('can match text content not containing a string', function (): void {
         });
 });
 
-it('matches containsText across collapsed whitespace', function (): void {
+it('matches containsText across collapsed whitespace when normalizing', function (): void {
     $this->view('nesting')
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->containsText('Foo Bar');
+            $element->containsText('Foo Bar', normalizeWhitespace: true);
         });
 });
 
-it('matches containsText against raw multiline text as a fallback', function (): void {
-    $this->view('nesting')
-        ->assertElementExists('pre.code', static function (AssertElement $element): void {
-            $element->containsText("line one\nline two");
-        });
-});
-
-it('matches doesntContainText against collapsed whitespace', function (): void {
+it('matches doesntContainText across collapsed whitespace when normalizing', function (): void {
     $this->view('nesting')
         ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
-            $element->doesntContainText('Bar Foo');
+            $element->doesntContainText('Bar Foo', normalizeWhitespace: true);
         });
 });
 


### PR DESCRIPTION
If you format blade, it introduces empty lines that then break containsText - we should allow some sort of normalisation.. 

seems to only affect containsText
