### PR TITLE
feat: add assertElementContainsText shorthand macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,16 @@ $this->get('/some-route')
     });
 ```
 
+For the common case of asserting a single element contains some text, `assertElementContainsText()` is a shorthand that skips the closure:
+
+```php
+$this->get('/some-route')
+    ->assertElementContainsText('#overview', 'Hello World')
+    ->assertElementContainsText('#overview', 'hello world', ignoreCase: true);
+```
+
+It selects the element (failing if the selector matches nothing), asserts its text contains the needle, and returns the response so calls can be chained.
+
 ### Whitespace normalisation
 
 By default these comparisons match text exactly as it appears in the DOM. Templates often introduce a lot of incidental whitespace, such as indented Blade, multi-line content, or `\r\n` line endings, so you can collapse and trim it instead.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,12 @@ $this->get('/some-route')
     ->assertElementContainsText('#overview', 'hello world', ignoreCase: true);
 ```
 
-It selects the element (failing if the selector matches nothing), asserts its text contains the needle, and returns the response so calls can be chained.
+It selects the element (failing if the selector matches nothing), asserts its text contains the needle, and returns the response so calls can be chained. It takes the same `$ignoreCase` and `$normalizeWhitespace` arguments as `containsText()`:
+
+```php
+$this->get('/some-route')
+    ->assertElementContainsText('#overview', 'Hello World', normalizeWhitespace: true);
+```
 
 ### Whitespace normalisation
 

--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -7,5 +7,6 @@ parameters:
     checkModelProperties: true
     ignoreErrors:
         - '#Call to an undefined method.*::getDomParser#' # We macro the parser so stan complains
+        - '#Call to an undefined method.*::assertElementExists#' # We macro the assertion so stan complains
     excludePaths:
         - %rootDir%/../../../src/Rector

--- a/src/TestComponentMacros.php
+++ b/src/TestComponentMacros.php
@@ -107,10 +107,10 @@ class TestComponentMacros
 
     public function assertElementContainsText(): Closure
     {
-        return function (string $selector, string $needle, bool $ignoreCase = false): TestComponent {
+        return function (string $selector, string $needle, bool $ignoreCase = false, ?bool $normalizeWhitespace = null): TestComponent {
             /** @var TestComponent $this */
-            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
-                $assert->containsText($needle, $ignoreCase);
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase, $normalizeWhitespace): void {
+                $assert->containsText($needle, $ignoreCase, $normalizeWhitespace);
             });
         };
     }

--- a/src/TestComponentMacros.php
+++ b/src/TestComponentMacros.php
@@ -105,6 +105,16 @@ class TestComponentMacros
         };
     }
 
+    public function assertElementContainsText(): Closure
+    {
+        return function (string $selector, string $needle, bool $ignoreCase = false): TestComponent {
+            /** @var TestComponent $this */
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
+                $assert->containsText($needle, $ignoreCase);
+            });
+        };
+    }
+
     public function assertContainsElement(): Closure
     {
         return function (string $selector, array $attributes = []): TestComponent {

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -116,10 +116,10 @@ class TestResponseMacros
 
     public function assertElementContainsText(): Closure
     {
-        return function (string $selector, string $needle, bool $ignoreCase = false): TestResponse {
+        return function (string $selector, string $needle, bool $ignoreCase = false, ?bool $normalizeWhitespace = null): TestResponse {
             /** @var TestResponse $this */
-            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
-                $assert->containsText($needle, $ignoreCase);
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase, $normalizeWhitespace): void {
+                $assert->containsText($needle, $ignoreCase, $normalizeWhitespace);
             });
         };
     }

--- a/src/TestResponseMacros.php
+++ b/src/TestResponseMacros.php
@@ -114,6 +114,16 @@ class TestResponseMacros
         };
     }
 
+    public function assertElementContainsText(): Closure
+    {
+        return function (string $selector, string $needle, bool $ignoreCase = false): TestResponse {
+            /** @var TestResponse $this */
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
+                $assert->containsText($needle, $ignoreCase);
+            });
+        };
+    }
+
     public function assertContainsElement(): Closure
     {
         return function (string $selector, array $attributes = []): TestResponse {

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -107,10 +107,10 @@ class TestViewMacros
 
     public function assertElementContainsText(): Closure
     {
-        return function (string $selector, string $needle, bool $ignoreCase = false): TestView {
+        return function (string $selector, string $needle, bool $ignoreCase = false, ?bool $normalizeWhitespace = null): TestView {
             /** @var TestView $this */
-            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
-                $assert->containsText($needle, $ignoreCase);
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase, $normalizeWhitespace): void {
+                $assert->containsText($needle, $ignoreCase, $normalizeWhitespace);
             });
         };
     }

--- a/src/TestViewMacros.php
+++ b/src/TestViewMacros.php
@@ -105,6 +105,16 @@ class TestViewMacros
         };
     }
 
+    public function assertElementContainsText(): Closure
+    {
+        return function (string $selector, string $needle, bool $ignoreCase = false): TestView {
+            /** @var TestView $this */
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
+                $assert->containsText($needle, $ignoreCase);
+            });
+        };
+    }
+
     public function assertContainsElement(): Closure
     {
         return function (string $selector, array $attributes = []): TestView {

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -515,6 +515,11 @@ it('assertElementContainsText can ignore case', function (): void {
         ->assertElementContainsText('p.foo.bar', 'bar', true);
 });
 
+it('assertElementContainsText can normalize whitespace', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('p.foo.bar', 'Foo Bar', normalizeWhitespace: true);
+});
+
 it('assertElementContainsText is chainable', function (): void {
     $this->component(NestedComponent::class)
         ->assertElementContainsText('span.foo', 'Foo')

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -504,3 +504,29 @@ it('can find text simplified', function (): void {
             $element->contains('span', 'Foo');
         });
 });
+
+it('assertElementContainsText works as expected', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('span.foo', 'Foo');
+});
+
+it('assertElementContainsText can ignore case', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('p.foo.bar', 'bar', true);
+});
+
+it('assertElementContainsText is chainable', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('span.foo', 'Foo')
+        ->assertElementContainsText('p.foo.bar', 'Bar');
+});
+
+it('assertElementContainsText throws if selector not found', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('span.non-existing', 'Foo');
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertElementContainsText throws if text does not match', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsText('span.foo', 'non-existing');
+})->throws(AssertionFailedError::class);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -578,6 +578,11 @@ it('assertElementContainsText can ignore case', function (): void {
         ->assertElementContainsText('p.foo.bar', 'bar', true);
 });
 
+it('assertElementContainsText can normalize whitespace', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('p.foo.bar', 'Foo Bar', normalizeWhitespace: true);
+});
+
 it('assertElementContainsText is chainable', function (): void {
     $this->get('nesting')
         ->assertElementContainsText('span.foo', 'Foo')

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -567,3 +567,29 @@ it('can find text simplified', function (): void {
             $element->contains('span', 'Foo');
         });
 });
+
+it('assertElementContainsText works as expected', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('span.foo', 'Foo');
+});
+
+it('assertElementContainsText can ignore case', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('p.foo.bar', 'bar', true);
+});
+
+it('assertElementContainsText is chainable', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('span.foo', 'Foo')
+        ->assertElementContainsText('p.foo.bar', 'Bar');
+});
+
+it('assertElementContainsText throws if selector not found', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('span.non-existing', 'Foo');
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertElementContainsText throws if text does not match', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsText('span.foo', 'non-existing');
+})->throws(AssertionFailedError::class);

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -495,6 +495,11 @@ it('assertElementContainsText can ignore case', function (): void {
         ->assertElementContainsText('p.foo.bar', 'bar', true);
 });
 
+it('assertElementContainsText can normalize whitespace', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('p.foo.bar', 'Foo Bar', normalizeWhitespace: true);
+});
+
 it('assertElementContainsText is chainable', function (): void {
     $this->view('nesting')
         ->assertElementContainsText('span.foo', 'Foo')

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -484,3 +484,29 @@ it('can find text simplified', function (): void {
             $element->contains('span', 'Foo');
         });
 });
+
+it('assertElementContainsText works as expected', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('span.foo', 'Foo');
+});
+
+it('assertElementContainsText can ignore case', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('p.foo.bar', 'bar', true);
+});
+
+it('assertElementContainsText is chainable', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('span.foo', 'Foo')
+        ->assertElementContainsText('p.foo.bar', 'Bar');
+});
+
+it('assertElementContainsText throws if selector not found', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('span.non-existing', 'Foo');
+})->throws(AssertionFailedError::class, 'No element found with selector: span.non-existing');
+
+it('assertElementContainsText throws if text does not match', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsText('span.foo', 'non-existing');
+})->throws(AssertionFailedError::class);


### PR DESCRIPTION
Adds a one-line shorthand for the common "select an element and assert its text contains a string" assertion, avoiding the assertElementExists closure + containsText() dance:

    ->assertElementContainsText('#overview', 'Hello World')
    ->assertElementContainsText('#overview', 'hello world', ignoreCase: true)

Implemented on all three macro classes (response, view, component) by reusing the existing assertElementExists + AssertElement::containsText path, so DOM resolution, failure messages, and return-for-chaining stay consistent. Covered by tests across DomTest/ViewTest/ComponentTest and documented in the README. PHPStan ignores the internal macro call in the same way the existing getDomParser call is ignored.