### PR TITLE
Add .gitattributes so composer install only provides files the end user needs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto eol=lf
+
+/.github export-ignore
+/build export-ignore
+/phpstan export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/CODEOWNERS export-ignore
+/CONTRIBUTING.md export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml export-ignore
+/pint.json export-ignore
+/rector.php export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,10 @@
-* text=auto eol=lf
+* text=auto
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
 
 /.github export-ignore
 /build export-ignore


### PR DESCRIPTION
Noticed this, by adding this it means end users only get the files they need which means a smaller dependency, faster install to the end user etc..