### PR TITLE
Add containsNormalizedText and doesntContainNormalizedText

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,13 @@ Enable it for a single call:
 $assert->containsText('Hello World', ignoreCase: false, normalizeWhitespace: true);
 ```
 
+Or use the dedicated methods, which always normalise regardless of the config value:
+
+```php
+$assert->containsNormalizedText('Hello World');
+$assert->doesntContainNormalizedText('Goodbye World');
+```
+
 Enable it globally from `TestCase::setUp()` or `AppServiceProvider::boot()`:
 
 ```php
@@ -489,6 +496,8 @@ $this->component(Navigation::class)
 | `doesntContainDiv(['class' => 'foo'])` | Magic method. Same as `doesntContain('div', ['class' => 'foo'])`. |
 | `containsText($needle, $ignoreCase = false, $normalizeWhitespace = null)` | Assert the element's text contains a string. `$normalizeWhitespace` defaults to the `dom-assertions.normalize_whitespace` config value when `null`. |
 | `doesntContainText($needle, $ignoreCase = false, $normalizeWhitespace = null)` | Assert the element's text does not contain a string. Same `$normalizeWhitespace` behaviour. |
+| `containsNormalizedText($needle, $ignoreCase = false)` | Same as `containsText()` with whitespace normalisation always on. |
+| `doesntContainNormalizedText($needle, $ignoreCase = false)` | Same as `doesntContainText()` with whitespace normalisation always on. |
 | `find($selector, $callback)` | Drill into the first matching child and receive a new `AssertElement`. |
 | `findDiv(fn (AssertElement $el) => ...)` | Magic method. Same as `find('div', ...)`. |
 | `each($selector, $callback)` | Run the callback against every matching child. |

--- a/ide-helper.php
+++ b/ide-helper.php
@@ -63,6 +63,12 @@ namespace Illuminate\Testing {
             return $instance;
         }
 
+        public function assertElementContainsNormalizedText($selector, $needle, $ignoreCase = false)
+        {
+            /** @var TestResponse $instance */
+            return $instance;
+        }
+
         public function ddContent(): void {}
     }
 
@@ -128,6 +134,12 @@ namespace Illuminate\Testing {
             return $instance;
         }
 
+        public function assertElementContainsNormalizedText($selector, $needle, $ignoreCase = false)
+        {
+            /** @var TestView $instance */
+            return $instance;
+        }
+
         public function ddContent(): void {}
     }
 
@@ -188,6 +200,12 @@ namespace Illuminate\Testing {
         }
 
         public function assertElementContainsText($selector, $needle, $ignoreCase = false, $normalizeWhitespace = null)
+        {
+            /** @var TestComponent $instance */
+            return $instance;
+        }
+
+        public function assertElementContainsNormalizedText($selector, $needle, $ignoreCase = false)
         {
             /** @var TestComponent $instance */
             return $instance;

--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -8,5 +8,6 @@ parameters:
     ignoreErrors:
         - '#Call to an undefined method.*::getDomParser#' # We macro the parser so stan complains
         - '#Call to an undefined method.*::assertElementExists#' # We macro the assertion so stan complains
+        - '#Call to an undefined method.*::assertElementContainsText#' # We macro the assertion so stan complains
     excludePaths:
         - %rootDir%/../../../src/Rector

--- a/src/Asserts/Traits/UsesElementAsserts.php
+++ b/src/Asserts/Traits/UsesElementAsserts.php
@@ -217,6 +217,16 @@ trait UsesElementAsserts
         return $this;
     }
 
+    public function containsNormalizedText(string $needle, bool $ignoreCase = false): self
+    {
+        return $this->containsText($needle, $ignoreCase, true);
+    }
+
+    public function doesntContainNormalizedText(string $needle, bool $ignoreCase = false): self
+    {
+        return $this->doesntContainText($needle, $ignoreCase, true);
+    }
+
     public function is(string $type): self
     {
         PHPUnit::assertEquals(

--- a/src/DomAssertionMacros.php
+++ b/src/DomAssertionMacros.php
@@ -118,6 +118,16 @@ abstract class DomAssertionMacros
         };
     }
 
+    public function assertElementContainsNormalizedText(): Closure
+    {
+        return function (string $selector, string $needle, bool $ignoreCase = false): TestComponent|TestResponse|TestView {
+            /** @var TestComponent|TestResponse|TestView $this */
+            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
+                $assert->containsNormalizedText($needle, $ignoreCase);
+            });
+        };
+    }
+
     public function assertContainsElement(): Closure
     {
         $emptyMessage = $this->emptyMessage();

--- a/src/DomAssertionMacros.php
+++ b/src/DomAssertionMacros.php
@@ -122,9 +122,7 @@ abstract class DomAssertionMacros
     {
         return function (string $selector, string $needle, bool $ignoreCase = false): TestComponent|TestResponse|TestView {
             /** @var TestComponent|TestResponse|TestView $this */
-            return $this->assertElementExists($selector, static function (AssertElement $assert) use ($needle, $ignoreCase): void {
-                $assert->containsNormalizedText($needle, $ignoreCase);
-            });
+            return $this->assertElementContainsText($selector, $needle, $ignoreCase, true);
         };
     }
 

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -579,3 +579,18 @@ it('assertElementContainsText throws if text does not match', function (): void 
     $this->component(NestedComponent::class)
         ->assertElementContainsText('span.foo', 'non-existing');
 })->throws(AssertionFailedError::class);
+
+it('assertElementContainsNormalizedText works as expected', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Foo Bar');
+});
+
+it('assertElementContainsNormalizedText can ignore case', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsNormalizedText('p.foo.bar', 'foo bar', ignoreCase: true);
+});
+
+it('assertElementContainsNormalizedText throws if text does not match', function (): void {
+    $this->component(NestedComponent::class)
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Bar Foo');
+})->throws(AssertionFailedError::class);

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -294,6 +294,50 @@ it('matches doesntContainText across collapsed whitespace when normalizing', fun
         });
 });
 
+it('matches containsNormalizedText across collapsed whitespace', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('matches containsNormalizedText ignoring case', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('foo bar', ignoreCase: true);
+        });
+});
+
+it('normalizes with containsNormalizedText when the config disables it', function (): void {
+    config()->set('dom-assertions.normalize_whitespace', false);
+
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('fails containsNormalizedText when the text is missing', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Bar Foo');
+        });
+})->throws(AssertionFailedError::class, 'Could not find text content "Foo Bar" containing Bar Foo');
+
+it('matches doesntContainNormalizedText across collapsed whitespace', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Bar Foo');
+        });
+});
+
+it('fails doesntContainNormalizedText when the text is present', function (): void {
+    $this->component(Html5Component::class)
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Foo Bar');
+        });
+})->throws(AssertionFailedError::class, 'Found text content "Foo Bar" containing Foo Bar');
+
 it('can match a class no matter the order', function (): void {
     $this->component(Html5Component::class)
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -642,3 +642,18 @@ it('assertElementContainsText throws if text does not match', function (): void 
     $this->get('nesting')
         ->assertElementContainsText('span.foo', 'non-existing');
 })->throws(AssertionFailedError::class);
+
+it('assertElementContainsNormalizedText works as expected', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Foo Bar');
+});
+
+it('assertElementContainsNormalizedText can ignore case', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'foo bar', ignoreCase: true);
+});
+
+it('assertElementContainsNormalizedText throws if text does not match', function (): void {
+    $this->get('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Bar Foo');
+})->throws(AssertionFailedError::class);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -278,6 +278,50 @@ it('matches doesntContainText across collapsed whitespace when normalizing', fun
         });
 });
 
+it('matches containsNormalizedText across collapsed whitespace', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('matches containsNormalizedText ignoring case', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('foo bar', ignoreCase: true);
+        });
+});
+
+it('normalizes with containsNormalizedText when the config disables it', function (): void {
+    config()->set('dom-assertions.normalize_whitespace', false);
+
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('fails containsNormalizedText when the text is missing', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Bar Foo');
+        });
+})->throws(AssertionFailedError::class, 'Could not find text content "Foo Bar" containing Bar Foo');
+
+it('matches doesntContainNormalizedText across collapsed whitespace', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Bar Foo');
+        });
+});
+
+it('fails doesntContainNormalizedText when the text is present', function (): void {
+    $this->get('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Foo Bar');
+        });
+})->throws(AssertionFailedError::class, 'Found text content "Foo Bar" containing Foo Bar');
+
 it('can match a class no matter the order', function (): void {
     $this->get('nesting')
         ->assertElementExists(static function (AssertElement $element): void {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -559,3 +559,18 @@ it('assertElementContainsText throws if text does not match', function (): void 
     $this->view('nesting')
         ->assertElementContainsText('span.foo', 'non-existing');
 })->throws(AssertionFailedError::class);
+
+it('assertElementContainsNormalizedText works as expected', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Foo Bar');
+});
+
+it('assertElementContainsNormalizedText can ignore case', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'foo bar', ignoreCase: true);
+});
+
+it('assertElementContainsNormalizedText throws if text does not match', function (): void {
+    $this->view('nesting')
+        ->assertElementContainsNormalizedText('p.foo.bar', 'Bar Foo');
+})->throws(AssertionFailedError::class);

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -277,6 +277,50 @@ it('matches doesntContainText across collapsed whitespace when normalizing', fun
         });
 });
 
+it('matches containsNormalizedText across collapsed whitespace', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('matches containsNormalizedText ignoring case', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('foo bar', ignoreCase: true);
+        });
+});
+
+it('normalizes with containsNormalizedText when the config disables it', function (): void {
+    config()->set('dom-assertions.normalize_whitespace', false);
+
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Foo Bar');
+        });
+});
+
+it('fails containsNormalizedText when the text is missing', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->containsNormalizedText('Bar Foo');
+        });
+})->throws(AssertionFailedError::class, 'Could not find text content "Foo Bar" containing Bar Foo');
+
+it('matches doesntContainNormalizedText across collapsed whitespace', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Bar Foo');
+        });
+});
+
+it('fails doesntContainNormalizedText when the text is present', function (): void {
+    $this->view('nesting')
+        ->assertElementExists('p.foo.bar', static function (AssertElement $element): void {
+            $element->doesntContainNormalizedText('Foo Bar');
+        });
+})->throws(AssertionFailedError::class, 'Found text content "Foo Bar" containing Foo Bar');
+
 it('can match a class no matter the order', function (): void {
     $this->view('nesting')
         ->assertElementExists(static function (AssertElement $element): void {


### PR DESCRIPTION
Adds dedicated methods for whitespace-normalized text assertions, so

```php
$element->containsText('Downloaded file02.txt', normalizeWhitespace: true);
```

becomes

```php
$element->containsNormalizedText('Downloaded file02.txt');
```

Both methods delegate to `containsText()` / `doesntContainText()` with `$normalizeWhitespace` forced to `true`, so they normalize regardless of the `dom-assertions.normalize_whitespace` config value. `$ignoreCase` is still supported as the second argument.

Tests added to `DomTest`, `ViewTest` and `ComponentTest`. README updated.